### PR TITLE
Some enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
-dist/
-*.sw[po]
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+.virtualenv
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config
+*~

--- a/fast-tags.cabal
+++ b/fast-tags.cabal
@@ -45,21 +45,40 @@ source-repository head
     type: git
     location: git://github.com/elaforge/fast-tags.git
 
-executable fast-tags
-    main-is: Main.hs
-    hs-source-dirs: src
-    build-depends: base >= 3 && < 5, containers,
-        -- text 0.11.1.12 has a bug.
-        text (> 0.11.1.12 || < 0.11.1.12)
-    ghc-options: -Wall -fno-warn-name-shadowing
+flag fast
+    description: Spend more time optimizing a program (may yield up to 25% speedup)
+    default:     False
 
-test-suite tests
-    type: exitcode-stdio-1.0
+library
+    build-depends: base >= 3 && < 5, containers, cpphs >1.18, filepath, directory,
+                   -- text 0.11.1.12 has a bug.
+                   text (> 0.11.1.12 || < 0.11.1.12)
+    exposed-modules: FastTags
     hs-source-dirs: src
-    main-is: Main_test.hs
-    build-depends: ghc,
-        base >= 3 && < 5, containers,
-        -- text 0.11.1.12 has a bug.
-        text (> 0.11.1.12 || < 0.11.1.12)
-    -- Needed for the srcloc hack.
-    ghc-options: -fno-ignore-asserts
+    ghc-options: -Wall -fno-warn-name-shadowing
+    ghc-prof-options: -Wall -fno-warn-name-shadowing -auto-all
+    if flag(fast)
+        ghc-options: -funfolding-creation-threshold=10000 -funfolding-use-threshold=2500
+
+executable fast-tags
+    main-is: src/Main.hs
+    build-depends: base >= 3 && < 5, containers, filepath, directory,
+                   -- text 0.11.1.12 has a bug.
+                   text (> 0.11.1.12 || < 0.11.1.12),
+                   fast-tags
+    ghc-options: -Wall -fno-warn-name-shadowing
+    ghc-prof-options: -Wall -fno-warn-name-shadowing -auto-all
+    if flag(fast)
+        ghc-options: -funfolding-creation-threshold=10000 -funfolding-use-threshold=2500
+
+test-suite test-fast-tags
+    type: exitcode-stdio-1.0
+    main-is: MainTest.hs
+    hs-source-dirs: tests
+    ghc-options: -main-is MainTest
+    ghc-prof-options: -main-is MainTest
+    build-depends: base >= 3 && < 5, containers, filepath, directory,
+                   -- text 0.11.1.12 has a bug.
+                   text (> 0.11.1.12 || < 0.11.1.12),
+                   tasty, tasty-hunit,
+                   fast-tags

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {- | Tagify haskell source.
 
@@ -6,70 +7,236 @@
     hsc. That way I can hook it to the editor's save action and always keep
     the tags up to date.
 -}
-module Main where
+module Main (main) where
+import Control.Applicative
 import Control.Monad
-import qualified Data.Either as Either
+import Data.Map (Map)
+import Data.Monoid
+import Data.Set (Set)
+import Data.Text (Text)
+import System.Console.GetOpt
+import System.Directory (doesFileExist, doesDirectoryExist, getDirectoryContents)
+import System.Exit
+import System.FilePath ((</>))
 import qualified Data.List as List
+import qualified Data.Map as Map
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text.IO
 
 import qualified System.Console.GetOpt as GetOpt
 import qualified System.Environment as Environment
-import qualified System.Exit
 import qualified System.IO as IO
 
 import FastTags
 
-
 main :: IO ()
 main = do
     args <- Environment.getArgs
-    (flags, inputs) <- case GetOpt.getOpt GetOpt.Permute options args of
+
+    (flags, inputs) <- case getOpt Permute options args of
         (flags, inputs, []) -> return (flags, inputs)
-        (_, _, errs) -> usage $ "flag errors:\n" ++ List.intercalate ", " errs
+        (_, _, errs)        -> let errMsg = "flag errors:\n" ++
+                                            List.intercalate ", " errs
+                               in usage $ errMsg ++ "\n" ++ help
+
+    when (Help `elem` flags) $ usage help
     when (null inputs) $
         usage "no input files\n"
-    let output = last $ "tags" : [fn | Output fn <- flags]
-        verbose = Verbose `elem` flags
-    oldTags <- fmap (maybe [vimMagicLine] Text.lines) $
-        catchENOENT $ Text.IO.readFile output
+
+    let verbose       = Verbose `elem` flags
+        emacs         = ETags `elem` flags
+        vim           = not emacs
+        trackPrefixes = emacs
+        recurse       = Recurse `elem` flags
+        output        = last $ defaultOutput : [fn | Output fn <- flags]
+        noMerge       = NoMerge `elem` flags
+        useZeroSep    = ZeroSep `elem` flags
+        ignoreEncErrs = IgnoreEncodingErrors `elem` flags
+        sep           = if useZeroSep then '\0' else '\n'
+        defaultOutput = if vim then "tags" else "TAGS"
+        inputsM       = if null inputs
+                        then split sep <$> getContents
+                        else fmap concat $ forM inputs $ \input -> do
+                            -- if an input is a directory then we find the
+                            -- haskell files inside it, optionally recursing
+                            -- further if the -R switch is specified
+                            isDirectory <- doesDirectoryExist input
+                            if isDirectory
+                                then filter isHsFile <$> contents recurse input
+                                else return [input]
+
+    oldTags <-
+      if vim && not noMerge
+         then do
+              exists <- doesFileExist output
+              if exists
+                then Text.lines <$> Text.IO.readFile output
+                else return [vimMagicLine]
+         else return [] -- we do not support tags merging for emacs
+                        -- for now
+
+    inputs <- inputsM
     -- This will merge and sort the new tags.  But I don't run it on the
     -- the result of merging the old and new tags, so tags from another
     -- file won't be sorted properly.  To do that I'd have to parse all the
     -- old tags and run processAll on all of them, which is a hassle.
     -- TODO try it and see if it really hurts performance that much.
-    newTags <- fmap (processAll . concat) $
-        forM (zip [0..] inputs) $ \(i :: Int, fn) -> do
-            tags <- processFile fn
-            -- This has the side-effect of forcing the the tags, which is
-            -- essential if I'm tagging a lot of files at once.
-            let (warnings, newTags) = Either.partitionEithers tags
-            forM_ warnings $ \warn -> do
-                IO.hPutStrLn IO.stderr warn
-            when verbose $ do
-                let line = show i ++ " of " ++ show (length inputs - 1)
-                        ++ ": " ++ fn
-                putStr $ '\r' : line ++ replicate (78 - length line) ' '
-                IO.hFlush IO.stdout
-            return newTags
+    newTags <- fmap processAll $
+      forM (zip [0..] inputs) $ \(i :: Int, fn) -> do
+        (newTags, warnings) <- processFile ignoreEncErrs fn trackPrefixes
+        forM_ warnings printErr
+        when verbose $ do
+          let line = take 78 $ show i ++ ": " ++ fn
+          putStr $ '\r' : line ++ replicate (78 - length line) ' '
+          IO.hFlush IO.stdout
+        return newTags
+
     when verbose $ putChar '\n'
 
-    let write = if output == "-" then Text.IO.hPutStr IO.stdout
+    let write =
+          if output == "-"
+            then Text.IO.hPutStr IO.stdout
             else Text.IO.writeFile output
-    write $ Text.unlines (mergeTags inputs oldTags newTags)
-    where
-    usage msg = do
-        putStr $ GetOpt.usageInfo
-            (msg ++ "\nusage: fast-tags file1 file2 ...") options
-        System.Exit.exitFailure
 
-data Flag = Output FilePath | Verbose
+    write $
+      if vim
+        then Text.unlines $ mergeTags inputs oldTags newTags
+        else Text.concat $ prepareEmacsTags newTags
+
+  where
+    usage msg = putStr (GetOpt.usageInfo msg options) >> exitFailure
+
+    printErr :: String -> IO ()
+    printErr = IO.hPutStrLn IO.stderr
+
+    contents recurse = if recurse
+                         then getRecursiveDirContents
+                         else getProperDirContents
+
+-- | Get all absolute filepaths contained in the supplied topdir,
+-- except "." and ".."
+getProperDirContents :: FilePath -> IO [FilePath]
+getProperDirContents topdir = do
+  names <- getDirectoryContents topdir
+  let properNames = filter (`notElem` [".", ".."]) names
+  return $ map ((</>) topdir) properNames
+
+-- | Recurse directories collecting all files
+getRecursiveDirContents :: FilePath -> IO [FilePath]
+getRecursiveDirContents topdir = do
+  paths  <- getProperDirContents topdir
+  paths' <- forM paths $ \path -> do
+    isDirectory <- doesDirectoryExist path
+    if isDirectory
+      then getRecursiveDirContents path
+      else return [path]
+  return (concat paths')
+
+
+type TagsTable = Map FilePath [Pos TagVal]
+
+prepareEmacsTags :: [Pos TagVal] -> [Text]
+prepareEmacsTags = printTagsTable . classifyTagsByFile
+
+printTagsTable :: TagsTable -> [Text]
+printTagsTable = map (uncurry printSection) . Map.assocs
+
+printSection :: FilePath -> [Pos TagVal] -> Text
+printSection file tags =
+  Text.concat ["\x0c\x0a", Text.pack file, ",",
+               Text.pack $ show tagsLength, "\x0a", tagsText]
+  where
+    tagsText = Text.unlines $ map printEmacsTag tags
+    tagsLength = Text.length tagsText
+
+printEmacsTag :: Pos TagVal -> Text
+printEmacsTag (Pos (SrcPos _file line) (TagVal prefix _text _type)) =
+  Text.concat [prefix, "\x7f", Text.pack (show line)]
+
+classifyTagsByFile :: [Pos TagVal] -> TagsTable
+classifyTagsByFile = foldr insertTag Map.empty
+
+insertTag :: Pos TagVal -> TagsTable -> TagsTable
+insertTag tag@(Pos (SrcPos file _) _) table =
+  Map.insertWith (<>) file [tag] table
+
+mergeTags :: [FilePath] -> [Text] -> [Pos TagVal] -> [Text]
+mergeTags inputs old new =
+  -- 'new' was already been sorted by 'process', but then I just concat
+  -- the tags from each file, so they need sorting again.
+  merge (map showTag new) (filter (not . isNewTag textFns) old)
+  where
+    textFns = Set.fromList $ map Text.pack inputs
+
+data Flag = Output FilePath
+          | Help
+          | Verbose
+          | ETags
+          | Recurse
+          | NoMerge
+          | ZeroSep
+          | IgnoreEncodingErrors
     deriving (Eq, Show)
 
-options :: [GetOpt.OptDescr Flag]
+help :: String
+help = "usage: fast-tags [options] [filenames]\n" ++
+       "In case no filenames provided on commandline, fast-tags expects " ++
+       "list of files separated by newlines in stdin."
+
+options :: [OptDescr Flag]
 options =
-    [ GetOpt.Option ['o'] [] (GetOpt.ReqArg Output "filename")
+    [ Option ['h'] ["help"] (NoArg Help)
+        "print help message"
+    , Option ['o'] [] (ReqArg Output "file")
         "output file, defaults to 'tags'"
-    , GetOpt.Option ['v'] [] (GetOpt.NoArg Verbose)
+    , Option ['e'] [] (NoArg ETags)
+        "print tags in Emacs format"
+    , Option ['v'] [] (NoArg Verbose)
         "print files as they are tagged, useful to track down slow files"
+    , Option ['R'] [] (NoArg Recurse)
+        "read all files under any specified directories recursively"
+    , Option ['0'] [] (NoArg ZeroSep)
+        "expect list of file names in stdin to be 0-separated."
+    , Option [] ["nomerge"] (NoArg NoMerge)
+        "do not merge tag files"
+    , Option [] ["ignore-encoding-errors"] (NoArg IgnoreEncodingErrors)
+        "do exit on utf8 encoding error and continue processing other files"
     ]
+
+-- | Documented in vim :h tags-file-format.
+-- This tells vim that the file is sorted (but not case folded) so that
+-- it can do a bsearch and never needs to fall back to linear search.
+vimMagicLine :: Text
+vimMagicLine = "!_TAG_FILE_SORTED\t1\t~"
+
+isNewTag :: Set Text -> Text -> Bool
+isNewTag textFns line = Set.member fn textFns
+  where
+    fn = Text.takeWhile (/='\t') $ Text.drop 1 $ Text.dropWhile (/='\t') line
+
+-- | Convert a Tag to text, e.g.: AbsoluteMark\tCmd/TimeStep.hs 67 ;" f
+showTag :: Pos TagVal -> Text
+showTag (Pos (SrcPos fn lineno) (TagVal _ text typ)) =
+  Text.concat
+    [ text
+    , "\t"
+    , Text.pack fn
+    , "\t"
+    , Text.pack (show lineno)
+    , " ;\" "
+    , Text.singleton (showType typ)
+    ]
+
+-- | Vim takes this to be the \"kind:\" annotation.  It's just an arbitrary
+-- string and these letters conform to no standard.  Presumably there are some
+-- vim extensions that can make use of it.
+showType :: Type -> Char
+showType typ = case typ of
+    Module      -> 'm'
+    Function    -> 'f'
+    Class       -> 'c'
+    Type        -> 't'
+    Constructor -> 'C'
+    Operator    -> 'o'
+    Pattern     -> 'p'

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -1,0 +1,637 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module MainTest where
+
+import qualified Control.Exception as Exception
+import Control.Monad
+import qualified Data.Either as Either
+import qualified Data.Monoid as Monoid
+import Data.Text (Text)
+import qualified Data.Text as T
+
+import Control.Exception (assert)
+import qualified System.IO.Unsafe as Unsafe
+
+import qualified FastTags
+import FastTags (UnstrippedTokens(..), TokenVal(..), TagVal(..), Type(..), Tag, Pos(..))
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = defaultMain tests
+
+
+tests :: TestTree
+tests = testGroup "tests"
+  [ testTokenize
+  , testSkipString
+  , testStripComments
+  , testBreakBlocks
+  , testProcessAll
+  , testProcess
+  ]
+
+test :: (Show a, Eq b, Show b) => (a -> b) -> a -> b -> TestTree
+test f x expected = testCase (take 70 $ show x) $ f x @?= expected
+
+testTokenize :: TestTree
+testTokenize = testGroup "tokenize"
+  [ "a::b->c"           ==> ["a", "::", "b", "->", "c"]
+  , "x{-\n  bc#-}\n"    ==> ["x", "{-", "nl 2", "bc#", "-}"]
+  , "X.Y"               ==> ["X.Y"]
+  , "x9"                ==> ["x9"]
+  -- , "9x" ==> ["nl 0", "9", "x"]
+  , "x :+: y"           ==> ["x", ":+:", "y"]
+  , "(#$)"              ==> ["(", "#$", ")"]
+  , "Data.Map.map"      ==> ["Data.Map.map"]
+  , "Map.map"           ==> ["Map.map"]
+  , "forall a. f a"     ==> ["forall", "a", ".", "f", "a"]
+  , "forall a . Foo"    ==> ["forall", "a", ".", "Foo"]
+  , "forall a. Foo"     ==> ["forall", "a", ".", "Foo"]
+  , "forall a .Foo"     ==> ["forall", "a", ".", "Foo"]
+  , "forall a.Foo"      ==> ["forall", "a", ".", "Foo"]
+  , "$#-- hi"           ==> ["$#--", "hi"]
+  , "(*), (-)"          ==> ["(", "*", ")", ",", "(", "-", ")"]
+  , "(.::)"             ==> ["(", ".::", ")"]
+  -- we rely on this behavior
+  , "data (:+) a b"     ==> ["data", "(", ":+", ")", "a", "b"]
+  , "data (.::+::) a b" ==> ["data", "(", ".::+::", ")", "a", "b"]
+  ]
+  where
+    (==>) = test f
+    f = tail . extractTokens . tokenize
+
+testSkipString :: TestTree
+testSkipString = testGroup "skipString"
+  [ "hi \" there"             ==> " there"
+  , "hi \\a \" there"         ==> " there"
+  , "hi \\\" there\""         ==> ""
+  , "hi"                      ==> ""
+  -- String continuation
+  , test f' "hi \\\n    \\bar\" baz" ("hi bar\"", " baz")
+  ]
+  where
+    (==>) = test f
+    f = snd . FastTags.breakString
+    f' = FastTags.breakString
+
+testStripComments :: TestTree
+testStripComments = testGroup "stripComments"
+  [ "hello -- there"                                           ==> ["nl 0", "hello"]
+  , "hello --there"                                            ==> ["nl 0", "hello"]
+  , "hello {- there -} fred"                                   ==> ["nl 0", "hello", "fred"]
+  , "hello -- {- there -}\nfred"                               ==> ["nl 0", "hello", "nl 0", "fred"]
+  , "{-# LANG #-} hello {- there {- nested -} comment -} fred" ==> ["nl 0", "hello", "fred"]
+  , "hello {-\nthere\n------}\n fred"                          ==> ["nl 0", "hello",  "nl 1", "fred"]
+  , "hello {-  \nthere\n  ------}  \n fred"                    ==> ["nl 0", "hello",  "nl 1", "fred"]
+  , "hello {-\nthere\n-----}\n fred"                           ==> ["nl 0", "hello", "nl 1", "fred"]
+  , "hello {-  \nthere\n  -----}  \n fred"                     ==> ["nl 0", "hello",  "nl 1", "fred"]
+  , "hello {-\n-- there -}"                                    ==> ["nl 0", "hello"]
+  , "foo --- my comment\n--- my other comment\nbar"            ==> ["nl 0", "foo", "nl 0", "nl 0", "bar"]
+  ]
+  where
+    (==>) = test f
+    f = extractTokens . FastTags.stripComments . tokenize
+
+testBreakBlocks :: TestTree
+testBreakBlocks = testGroup "breakBlocks"
+  [ "1\n2\n"           ==> [["1"], ["2"]]
+  , "1\n 1\n2\n"       ==> [["1", "1"], ["2"]]
+  , "1\n 1\n 1\n2\n"   ==> [["1", "1", "1"], ["2"]]
+  -- intervening blank lines are ignored
+  , "1\n 1\n\n 1\n2\n" ==> [["1", "1", "1"], ["2"]]
+  , "1\n\n\n 1\n2\n"   ==> [["1", "1"], ["2"]]
+
+  , "1\n 11\n 11\n"    ==> [["1", "11", "11"]]
+  , " 11\n 11\n"       ==> [["11"], ["11"]]
+  ]
+  where
+    (==>) = test f
+    f = map (extractTokens . UnstrippedTokens . FastTags.stripNewlines)
+        . FastTags.breakBlocks . tokenize
+
+testProcessAll :: TestTree
+testProcessAll = testGroup "processAll"
+  [ ["data X", "module X"]     ==> ["fn0:1 X Type", "fn1:1 X Module"]
+  -- Type goes ahead of Module.
+  , ["module X\n\
+     \data X"]       ==> ["fn0:2 X Type", "fn0:1 X Module"]
+  -- Extra X was filtered.
+  , ["module X\n\
+     \data X = X\n"] ==> ["fn0:2 X Type", "fn0:1 X Module"]
+  , ["module X\n\
+     \data X a =\n\
+     \  X a\n"] ==> ["fn0:2 X Type", "fn0:1 X Module"]
+  , ["newtype A f a b = A\n\
+     \  { unA :: f (a -> b) }"]
+    ==> ["fn0:1 A Type", "fn0:2 unA Function"]
+  ]
+  where
+    (==>) = test f
+    f = map showTag
+        . FastTags.processAll
+        . map (\(i, t) -> fst $ FastTags.process ("fn" ++ show i) False t)
+        . zip [0..]
+    showTag (Pos p (TagVal _ text typ)) =
+      unwords [show p, T.unpack text, show typ]
+
+testProcess :: TestTree
+testProcess = testGroup "process"
+  [ testMisc
+  , testData
+  , testGADT
+  , testFamilies
+  , testFunctions
+  , testClass
+  , testInstance
+  , testLiterate
+  , testPatterns
+  , testFFI
+  ]
+
+testMisc :: TestTree
+testMisc = testGroup "misc"
+  [ "module Bar.Foo where\n"
+    ==>
+    [TagVal "module Bar.Foo" "Foo" Module]
+  , "newtype Foo a b =\n\
+    \\tBar x y z\n"
+    ==>
+    [ TagVal "\tBar" "Bar" Constructor
+    ,  TagVal "newtype Foo" "Foo" Type
+    ]
+  , "f :: A -> B\n\
+    \g :: C -> D\n\
+    \data D = C {\n\
+    \\tf :: A\n\
+    \\t}\n"
+    ==>
+    [ TagVal "data D = C" "C" Constructor
+    , TagVal "data D" "D" Type
+    , TagVal "\tf" "f" Function
+    , TagVal "f" "f" Function
+    , TagVal "g" "g" Function
+    ]
+  ]
+  where
+    (==>) = test f
+    f = map valOf . fst . FastTags.process "fn.hs" False
+
+testData :: TestTree
+testData = testGroup "data"
+  [ "data X\n"                            ==> ["X"]
+  , "data X = X Int\n"                    ==> ["X", "X"]
+  , "data Foo = Bar | Baz"                ==> ["Bar", "Baz", "Foo"]
+  , "data Foo =\n\tBar\n\t| Baz"          ==> ["Bar", "Baz", "Foo"]
+  -- Records.
+  , "data Foo a = Bar { field :: Field }" ==> ["Bar", "Foo", "field"]
+  , "data R = R { a::X, b::Y }"           ==> ["R", "R", "a", "b"]
+  , "data R = R {\n\ta::X\n\t, b::Y\n\t}" ==> ["R", "R", "a", "b"]
+  , "data R = R {\n\ta,b::X\n\t}"         ==> ["R", "R", "a", "b"]
+
+  , "data R = R {\n\
+    \    a :: !RealTime\n\
+    \  , b :: !RealTime\n\
+    \}"
+    ==>
+    ["R", "R", "a", "b"]
+  , "data Rec = Rec {\n\
+    \  a :: Int\n\
+    \, b :: !Double\n\
+    \, c :: Maybe Rec\
+    \\n\
+    \}"
+    ==>
+    ["Rec", "Rec", "a", "b", "c"]
+
+  , "data X = X !Int"                 ==> ["X", "X"]
+  , "data X = Y !Int !X | Z"          ==> ["X", "Y", "Z"]
+  , "data X = Y :+: !Z | !X `Mult` X" ==> [":+:", "Mult", "X"]
+  , "data X = !Y `Add` !Z"            ==> ["Add", "X"]
+
+  , "data X = forall a. Y a"                   ==> ["X", "Y"]
+  , "data X = forall a . Y a"                  ==> ["X", "Y"]
+  , "data X = forall a .Y a"                   ==> ["X", "Y"]
+  , "data X = forall a.Y a"                    ==> ["X", "Y"]
+  , "data X = forall a. Eq a => Y a"           ==> ["X", "Y"]
+  , "data X = forall a. (Eq a) => Y a"         ==> ["X", "Y"]
+  , "data X = forall a. (Eq a, Ord a) => Y a"  ==> ["X", "Y"]
+  -- "data X = forall a. Ref :<: a => Y a"     ==> ["X", "Y"]
+  -- "data X = forall a. (:<:) Ref a => Y a"   ==> ["X", "Y"]
+  , "data X = forall a. ((:<:) Ref a) => Y a"  ==> ["X", "Y"]
+  , "data X = forall a. Y !a"                  ==> ["X", "Y"]
+  , "data X = forall a. (Eq a, Ord a) => Y !a" ==> ["X", "Y"]
+
+  , "data Foo a = \n\
+    \    Plain Int\n\
+    \  | forall a. Bar a Int\n\
+    \  | forall a b. Baz b a\n\
+    \  | forall a . Quux a \
+    \  | forall a .Quuz a"
+    ==>
+    ["Bar", "Baz", "Foo", "Plain", "Quux", "Quuz"]
+
+  , "data X a = Add a "                     ==> ["Add", "X"]
+  , "data Eq a => X a = Add a"              ==> ["Add", "X"]
+  , "data (Eq a) => X a = Add a"            ==> ["Add", "X"]
+  , "data (Eq a, Ord a) => X a = Add a"     ==> ["Add", "X"]
+  , "data (Eq (a), Ord (a)) => X a = Add a" ==> ["Add", "X"]
+
+  -- These are hard-to-deal-with uses of contexts, which are probably not that
+  -- common and therefoce can be ignored.
+  -- "data Ref :<: f => X f = RRef f" ==> ["X", "RRef"]
+  -- "data a :<: b => X a b = Add a" ==> ["X", "Add"]
+  , "data (a :<: b) => X a b = Add a" ==> ["Add", "X"]
+
+  , "newtype Eq a => X a = Add a"          ==> ["Add", "X"]
+  , "newtype (Eq a) => X a = Add a"        ==> ["Add", "X"]
+  , "newtype (Eq a, Ord a) => X a = Add a" ==> ["Add", "X"]
+
+  , "newtype (u :*: v) z = X"      ==> [":*:", "X"]
+  , "data (u :*: v) z = X"         ==> [":*:", "X"]
+  , "type (u :*: v) z = (u, v, z)" ==> [":*:"]
+
+  , "newtype ((u :: (* -> *) -> *) :*: v) z = X"      ==> [":*:", "X"]
+  , "data ((u :: (* -> *) -> *) :*: v) z = X"         ==> [":*:", "X"]
+  , "type ((u :: (* -> *) -> *) :*: v) z = (u, v, z)" ==> [":*:"]
+
+  , "newtype (Eq (v z)) => ((u :: (* -> *) -> *) :*: v) z = X"      ==> [":*:", "X"]
+  , "data (Eq (v z)) => ((u :: (* -> *) -> *) :*: v) z = X"         ==> [":*:", "X"]
+  , "type (Eq (v z)) => ((u :: (* -> *) -> *) :*: v) z = (u, v, z)" ==> [":*:"]
+
+  , "newtype Eq (v z) => ((u :: (* -> *) -> *) :*: v) z = X"      ==> [":*:", "X"]
+  , "data Eq (v z) => ((u :: (* -> *) -> *) :*: v) z = X"         ==> [":*:", "X"]
+  , "type Eq (v z) => ((u :: (* -> *) -> *) :*: v) z = (u, v, z)" ==> [":*:"]
+
+  , "newtype (Eq (v z)) => ((u :: (* -> *) -> *) `Foo` v) z = X"      ==> ["Foo", "X"]
+  , "data (Eq (v z)) => ((u :: (* -> *) -> *) `Foo` v) z = X"         ==> ["Foo", "X"]
+  , "type (Eq (v z)) => ((u :: (* -> *) -> *) `Foo` v) z = (u, v, z)" ==> ["Foo"]
+
+  , "newtype Eq (v z) => ((u :: (* -> *) -> *) `Foo` v) z = X"      ==> ["Foo", "X"]
+  , "data Eq (v z) => ((u :: (* -> *) -> *) `Foo` v) z = X"         ==> ["Foo", "X"]
+  , "type Eq (v z) => ((u :: (* -> *) -> *) `Foo` v) z = (u, v, z)" ==> ["Foo"]
+
+  , "data (:*:) u v z = X"                        ==> [":*:", "X"]
+  , "data (Eq (u v), Ord (z)) => (:*:) u v z = X" ==> [":*:", "X"]
+  , "data (u `W` v) z = X"                        ==> ["W", "X"]
+  , "data (Eq (u v), Ord (z)) => (u `W` v) z = X" ==> ["W", "X"]
+
+  , "newtype X a = Z {\n\
+    \ -- TODO blah\n\
+    \ foo :: [a] }"
+    ==>
+    ["X", "Z", "foo"]
+  , "newtype (u :*: v) z = X {\n\
+    \ -- my insightful comment\n\
+    \ extract :: (u (v z)) }"
+    ==>
+    [":*:", "X", "extract"]
+
+  , "data Hadron a b = Science { f :: a, g :: a, h :: b }"
+    ==>
+    ["Hadron", "Science", "f", "g", "h"]
+  , "data Hadron a b = Science { f :: a, g :: (a, b), h :: b }"
+    ==>
+    ["Hadron", "Science", "f", "g", "h"]
+  , "data Hadron a b = forall x. Science { f :: x, h :: b }"
+    ==>
+    ["Hadron", "Science", "f", "h"]
+  , "data Hadron a b = forall x. Science { f :: [x], h :: b }"
+    ==>
+    ["Hadron", "Science", "f", "h"]
+  , "data Hadron a b = forall x y. Science { f :: (x, y), h :: b }"
+    ==>
+    ["Hadron", "Science", "f", "h"]
+  , "data Hadron a b = forall x y. Science { f :: [(x, y)], h :: b }"
+    ==>
+    ["Hadron", "Science", "f", "h"]
+  , "data Hadron a b = forall x y. Science { f :: [(Box x, Map x y)], h :: b }"
+    ==>
+    ["Hadron", "Science", "f", "h"]
+  , "data Hadron a b = forall x y z. Science\n\
+    \  { f :: x\n\
+    \  , g :: [(Box x, Map x y, z)] \
+    \  }"
+    ==>
+    ["Hadron", "Science", "f", "g"]
+  , "data Hadron a b = forall x y z. Science\n\
+    \  { f :: x\n\
+    \  , g :: [(Box x, Map x y, z)] \
+    \  , h :: b\n\
+    \  }"
+    ==>
+    ["Hadron", "Science", "f", "g", "h"]
+  , "data Hadron a b = Science { h :: b }"
+    ==>
+    ["Hadron", "Science", "h"]
+  , "data Test a b =\n\
+    \    Foo a\n\
+    \  | Bar [(Maybe a, Map a b, b)]"
+    ==>
+    ["Bar", "Foo", "Test"]
+  , "data Test a b =\n\
+    \    Foo a\n\
+    \  | [(Maybe b, Map b a, a)] `Bar` [(Maybe a, Map a b, b)]"
+    ==>
+    ["Bar", "Foo", "Test"]
+  ]
+  where
+    (==>) = test process
+
+testGADT :: TestTree
+testGADT = testGroup "gadt"
+  [ "data X where A :: X\n"              ==> ["A", "X"]
+  , "data X where\n\tA :: X\n"           ==> ["A", "X"]
+  , "data X where\n\tA :: X\n\tB :: X\n" ==> ["A", "B", "X"]
+  , "data X where\n\tA, B :: X\n"        ==> ["A", "B", "X"]
+  , "data X :: * -> * -> * where\n\
+    \  A, B :: Int -> Int -> X\n"
+    ==>
+    ["A", "B", "X"]
+  , "data Vec ix where\n\
+    \  Nil   :: Int -> Foo Int\n\
+    \  (:::) :: Int -> Vec Int -> Vec Int\n\
+    \  (.+.) :: Int -> Int -> Vec Int -> Vec Int\n"
+    ==>
+    [".+.", ":::", "Nil", "Vec"]
+  , "data Vec ix where\n\
+    \  Nil   :: Int -> Foo Int\n\
+    \  -- foo\n\
+    \  (:::) :: Int -> Vec Int -> Vec Int\n\
+    \-- bar\n\
+    \  (.+.) :: Int     -> \n\
+    \           -- ^ baz\n\
+    \           Int     -> \n\
+    \           Vec Int -> \n\
+    \Vec Int\n"
+    ==>
+    [".+.", ":::", "Nil", "Vec"]
+  , "data NatSing (n :: Nat) where\n    ZeroSing :: 'Zero\n    SuccSing :: NatSing n -> NatSing ('Succ n)\n"
+    ==>
+    ["NatSing", "SuccSing", "ZeroSing"]
+  ]
+  where
+    (==>) = test process
+
+testFamilies :: TestTree
+testFamilies = testGroup "families"
+  [ "type family X :: *\n"      ==> ["X"]
+  , "data family X :: * -> *\n" ==> ["X"]
+  , "data family a ** b"        ==> ["**"]
+
+  , "type family a :<: b\n"                               ==> [":<:"]
+  , "type family (a :: Nat) :<: (b :: Nat) :: Nat\n"      ==> [":<:"]
+  , "type family (a :: Nat) `Family` (b :: Nat) :: Nat\n" ==> ["Family"]
+  , "type family (m :: Nat) <=? (n :: Nat) :: Bool"       ==> ["<=?"]
+
+  , "data instance X a b = Y a | Z { unZ :: b }"                  ==> ["Y", "Z", "unZ"]
+  , "data instance (Eq a, Eq b) => X a b = Y a | Z { unZ :: b }"  ==> ["Y", "Z", "unZ"]
+  , "data instance XList Char = XCons !Char !(XList Char) | XNil" ==> ["XCons", "XNil"]
+  , "newtype instance Cxt x => T [x] = A (B x) deriving (Z,W)"    ==> ["A"]
+  , "data instance G [a] b where\n\
+    \   G1 :: c -> G [Int] b\n\
+    \   G2 :: G [a] Bool"
+    ==>
+    ["G1", "G2"]
+  , "class C where\n\ttype X y :: *\n" ==> ["C", "X"]
+  , "class C where\n\tdata X y :: *\n" ==> ["C", "X"]
+  ]
+  where
+    (==>) = test process
+
+testFunctions :: TestTree
+testFunctions = testGroup "functions"
+  [
+  -- Multiple declarations.
+    "a,b::X"      ==> ["a", "b"]
+  -- With an operator.
+  , "(+), a :: X" ==> ["+", "a"]
+  -- Don't get fooled by literals.
+  , "1 :: Int"    ==> []
+
+  -- plain functions and operators
+  , "(.::) :: X -> Y" ==> [".::"]
+  , "(:::) :: X -> Y" ==> [":::"]
+  , "(->:) :: X -> Y" ==> ["->:"]
+  , "(--+) :: X -> Y" ==> ["--+"]
+  , "(=>>) :: X -> Y" ==> ["=>>"]
+
+  , "_g :: X -> Y" ==> ["_g"]
+  , toplevelFunctionsWithoutSignatures
+  , toplevelFunctionsWithoutSignatures
+  ]
+  where
+    (==>) = test process
+    toplevelFunctionsWithoutSignatures =
+      testGroup "toplevel functions without signatures"
+        [ "infix 5 |+|"  ==> []
+        , "infixl 5 |+|" ==> []
+        , "infixr 5 |+|" ==> []
+        , "f = g"        ==> ["f"]
+        , "f :: a -> b -> a\n\
+          \f x y = x"
+          ==>
+          ["f"]
+        , "f x y = x"   ==> ["f"]
+        , "f (x :+: y) z = x" ==> ["f"]
+        , "(x :+: y) `f` z = x" ==> ["f"]
+        , "(x :+: y) :*: z = x" ==> [":*:"]
+        , "((:+:) x y) :*: z = x" ==> [":*:"]
+        , "(:*:) (x :+: y) z = x" ==> [":*:"]
+        , "(:*:) ((:+:) x y) z = x" ==> [":*:"]
+        , strictMatchTests
+        , lazyMatchTests
+        , "f x Nothing = x\n\
+          \f x (Just y) = y"
+          ==>
+          ["f"]
+        , "f x y = g x\n\
+          \  where\n\
+          \    g _ = y"
+          ==>
+          ["f"]
+        , "x `f` y = x"   ==> ["f"]
+        , "(|+|) x y = x" ==> ["|+|"]
+        , "x |+| y = x"   ==> ["|+|"]
+        , "(!) x y = x" ==> ["!"]
+        , "--- my comment" ==> []
+        ]
+    strictMatchTests = testGroup "strict match (!)"
+      [ "f !x y = x"  ==> ["f"]
+      , "f x !y = x"  ==> ["f"]
+      , "f !x !y = x" ==> ["f"]
+      , "f ! x y = x" ==> ["f"]
+      -- this one is a bit controversial but it seems to be the way ghc parses it
+      , "f ! x = x"   ==> ["f"]
+      , "(:*:) !(x :+: y) z = x" ==> [":*:"]
+      , "(:*:) !(!x :+: !y) !z = x" ==> [":*:"]
+      , "(:*:) !((:+:) x y) z = x" ==> [":*:"]
+      , "(:*:) !((:+:) !x !y) !z = x" ==> [":*:"]
+      , "(!) :: a -> b -> a\n\
+        \(!) x y = x"
+        ==>
+        ["!"]
+      -- this is a degenerate case since even ghc treats ! here as
+      -- a BangPatterns instead of operator
+      , "x ! y = x" ==> ["x"]
+      ]
+    lazyMatchTests = testGroup "lazy match (~)"
+      [ "f ~x y = x"  ==> ["f"]
+      , "f x ~y = x"  ==> ["f"]
+      , "f ~x ~y = x" ==> ["f"]
+      , "f ~ x y = x" ==> ["f"]
+      -- this one is a bit controversial but it seems to be the way ghc parses it
+      , "f ~ x = x"   ==> ["f"]
+      , "(:*:) ~(x :+: y) z = x" ==> [":*:"]
+      , "(:*:) ~(~x :+: ~y) ~z = x" ==> [":*:"]
+      , "(:*:) ~((:+:) x y) z = x" ==> [":*:"]
+      , "(:*:) ~((:+:) ~x ~y) ~z = x" ==> [":*:"]
+      , "(~) :: a -> b -> a\n\
+        \(~) x y = x"
+        ==>
+        ["~"]
+      -- this is a degenerate case since even ghc treats ~ here as
+      -- a BangPatterns instead of operator
+      , "x ~ y = x" ==> ["x"]
+      ]
+
+testClass :: TestTree
+testClass = testGroup "class"
+  [ "class (X x) => C a b where\n\tm :: a->b\n\tn :: c\n" ==> ["C", "m", "n"]
+  , "class A a where f :: X\n"                            ==> ["A", "f"]
+    -- indented inside where
+  , "class X where\n\ta, (+) :: X\n"            ==> ["+", "X", "a"]
+  , "class X where\n\ta :: X\n\tb, c :: Y"      ==> ["X", "a", "b", "c"]
+  , "class X\n\twhere\n\ta :: X\n\tb, c :: Y"   ==> ["X", "a", "b", "c"]
+  , "class X\n\twhere\n\ta ::\n\t\tX\n\tb :: Y" ==> ["X", "a", "b"]
+
+  , "class a :<: b where\n    f :: a -> b"         ==> [":<:", "f"]
+  , "class (:<:) a b where\n    f :: a -> b"       ==> [":<:", "f"]
+  , "class Eq a => a :<: b where\n    f :: a -> b" ==> [":<:", "f"]
+  -- , "class a :<<<: b => a :<: b where\n    f :: a -> b"
+  --   ==>
+  --   [":<:", "f"]
+  , "class (a :<<<: b) => a :<: b where\n    f :: a -> b"   ==> [":<:", "f"]
+  , "class (Eq a, Ord b) => a :<: b where\n    f :: a -> b" ==> [":<:", "f"]
+  , "class (Eq a, Ord b) => (a :: (* -> *) -> *) :<: b where\n    f :: a -> b"
+    ==>
+    [":<:", "f"]
+    -- this is bizzarre
+  , "class (Eq (a), Ord (f a [a])) => f `Z` a" ==> ["Z"]
+
+  , "class A f where\n  data F f :: *\n  g :: a -> f a\n  h :: f a -> a"
+    ==>
+    ["A", "F", "g", "h"]
+  , "class A f where\n  data F f :: *\n  mkF :: f -> F f\n  getF :: F f -> f"
+    ==>
+    ["A", "F", "getF", "mkF"]
+  , "class A f where\n\
+    \  data F f :: * -- foo\n\
+    \                -- bar\n\
+    \                -- baz\n\
+    \  mkF  :: f -> F f\n\
+    \  getF :: F f -> f"
+    ==>
+    ["A", "F", "getF", "mkF"]
+  -- Not confused by a class context on a method.
+  , "class X a where\n\tfoo :: Eq a => a -> a\n" ==> ["X", "foo"]
+  ]
+  where
+    (==>) = test process
+
+testInstance :: TestTree
+testInstance = testGroup "instance"
+  [ "instance Foo Quux where\n\
+    \  data Bar Quux a = QBar { frob :: a }\n\
+    \                  | QBaz { fizz :: String }\n\
+    \                  deriving (Show)"
+    ==>
+    ["QBar", "QBaz", "fizz", "frob"]
+  , "instance Foo Quux where\n\
+    \  data Bar Quux a = QBar a | QBaz String deriving (Show)"
+    ==>
+    ["QBar", "QBaz"]
+  , "instance Foo Quux where\n\
+    \  data Bar Quux a = QBar { frob :: a }\n\
+    \                  | QBaz { fizz :: String }\n\
+    \                  deriving (Show)\n\
+    \  data IMRuunningOutOfNamesHere Quux = Whatever"
+    ==>
+    ["QBar", "QBaz", "Whatever", "fizz", "frob"]
+    -- in this test foo function should not affect tags found
+  , "instance Foo Quux where\n\
+    \  data Bar Quux a = QBar { frob :: a }\n\
+    \                  | QBaz { fizz :: String }\n\
+    \                  deriving (Show)\n\
+    \\n\
+    \  foo _ = QBaz \"hey there\""
+    ==>
+    ["QBar", "QBaz", "fizz", "frob"]
+  , "instance Foo Int where foo _ = 1"
+    ==>
+    []
+  , "instance Foo Quux where\n\
+    \  newtype Bar Quux a = QBar a \n\
+    \                     deriving (Show)\n\
+    \\n\
+    \  foo _ = QBaz \"hey there\""
+    ==>
+    ["QBar"]
+  , "instance Foo Quux where\n\
+    \  newtype Bar Quux a = QBar { frob :: a }"
+    ==>
+    ["QBar", "frob"]
+  ]
+  where
+    (==>) = test process
+
+testLiterate :: TestTree
+testLiterate = testGroup "literate"
+  [ "> class (X x) => C a b where\n>\tm :: a->b\n>\tn :: c\n"
+    ==>
+    ["C", "m", "n"]
+  , "Test\n\\begin{code}\nclass (X x) => C a b where\n\tm :: a->b\n\tn :: c\n\\end{code}"
+    ==>
+    ["C", "m", "n"]
+  ]
+  where
+    (==>) = test f
+    f = map untag . fst . FastTags.process "fn.lhs" False
+
+testPatterns :: TestTree
+testPatterns = testGroup "patterns"
+  [ "pattern Arrow a b = ConsT \"->\" [a, b]"
+    ==>
+    ["Arrow"]
+  , "pattern Arrow a b = ConsT \"->\" [a, b]\n\
+    \pattern Pair a b = [a, b]"
+    ==>
+    ["Arrow", "Pair"]
+  ]
+  where
+    (==>) = test process
+
+testFFI :: TestTree
+testFFI = testGroup "ffi"
+  [ "foreign import ccall foo :: Double -> IO Double" ==> ["foo"]
+  , "foreign import unsafe java foo :: Double -> IO Double" ==> ["foo"]
+  , "foreign import safe stdcall foo :: Double -> IO Double" ==> ["foo"]
+  ]
+  where
+    (==>) = test process
+
+process :: Text -> [String]
+process = map untag . fst . FastTags.process "fn.hs" False
+
+untag :: Pos TagVal -> String
+untag (Pos _ (TagVal _ name _)) = T.unpack name
+
+tokenize :: Text -> UnstrippedTokens
+tokenize =
+  Monoid.mconcat . map (FastTags.tokenize False) . FastTags.stripCpp . FastTags.annotate "fn"
+
+extractTokens :: UnstrippedTokens -> [Text]
+extractTokens = map (\token -> case FastTags.valOf token of
+  Token _ name -> name
+  Newline n -> T.pack ("nl " ++ show n)) . FastTags.unstrippedTokensOf


### PR DESCRIPTION
Hi, this is pull request of some features added to fast-tagsin period after version 0.0.5 when it wasn't particularly actively developed in the main repository.

New features include:
* recognize more syntactic constructs (consider tests as specification of what's handled)
* add more tests
* use tasty to organize tests
* ability to produce emacs tags
* handling of literate files
* new mode to recursively traverse directory tree and search for haskell files
* optionally ignore encoding errors during reading and skip offending files
* ability to read \n-separated or \0-separated list of files from stdin
* and blazing-fast speed of tag generation is presevred

I realize that this pull request is anything but atomic but it contains some useful features that I believe should be in the official repository.