### PR TITLE
Handling of @-patterns, sorting fix, collect tags of .hsc files

### DIFF
--- a/fast-tags.cabal
+++ b/fast-tags.cabal
@@ -52,7 +52,7 @@ flag fast
 library
     build-depends: base >= 3 && < 5, containers, cpphs >1.18, filepath, directory,
                    -- text 0.11.1.12 has a bug.
-                   text (> 0.11.1.12 || < 0.11.1.12)
+                   text (> 0.11.1.12 || < 0.11.1.12), deepseq
     exposed-modules: FastTags
     hs-source-dirs: src
     ghc-options: -Wall -fno-warn-name-shadowing

--- a/src/FastTags.hs
+++ b/src/FastTags.hs
@@ -923,7 +923,10 @@ tailSafe (_:xs) = xs
 
 -- | Crude predicate for Haskell files
 isHsFile :: FilePath -> Bool
-isHsFile fn = ".hs" `L.isSuffixOf` fn || isLiterateFile fn
+isHsFile fn =
+  ".hs" `L.isSuffixOf` fn  ||
+  ".hsc" `L.isSuffixOf` fn ||
+  isLiterateFile fn
 
 isLiterateFile :: FilePath -> Bool
 isLiterateFile fn = ".lhs" `L.isSuffixOf` fn

--- a/src/FastTags.hs
+++ b/src/FastTags.hs
@@ -35,6 +35,7 @@ where
 
 import Control.Arrow
 import Control.Monad
+import Control.DeepSeq
 import Data.IntSet (IntSet)
 import Data.Function (on)
 import Data.Monoid
@@ -57,8 +58,14 @@ import qualified System.IO as IO
 
 -- * types
 
-data TagVal = TagVal !Text !Text !Type
+data TagVal = TagVal
+                !Text -- ^ prefix
+                !Text -- ^ name
+                !Type -- ^ tag type
   deriving (Show)
+
+instance NFData TagVal where
+  rnf (TagVal x y z) = rnf x `seq` rnf y `seq` rnf z
 
 instance Eq TagVal where
   TagVal _ name t == TagVal _ name' t' = name == name' && t == t'
@@ -77,6 +84,15 @@ data Type =
   | Operator
   | Pattern
   deriving (Eq, Ord, Show)
+
+instance NFData Type where
+  rnf Function    = ()
+  rnf Type        = ()
+  rnf Constructor = ()
+  rnf Class       = ()
+  rnf Module      = ()
+  rnf Operator    = ()
+  rnf Pattern     = ()
 
 data TokenVal =
     Token !Text !Text
@@ -134,10 +150,16 @@ data Pos a = Pos
   }
   deriving (Eq, Ord)
 
+instance (NFData a) => NFData (Pos a) where
+  rnf (Pos x y) = rnf x `seq` rnf y
+
 data SrcPos = SrcPos
   { _posFile :: !FilePath
   , posLine  :: !Int
   } deriving (Eq, Ord)
+
+instance NFData SrcPos where
+  rnf (SrcPos x y) = rnf x `seq` rnf y
 
 instance Show a => Show (Pos a) where
   show (Pos pos val) = show pos ++ ":" ++ show val

--- a/src/FastTags.hs
+++ b/src/FastTags.hs
@@ -156,18 +156,9 @@ processAll =
   where
     isDuplicatePair :: Pos TagVal -> Pos TagVal -> Bool
     isDuplicatePair t t' =
-      f == f' &&
-      (l == l' ||
-       -- special hack to handle the case when type is on a separate line and
-       -- constructor is on the next, e.g.
-       -- data Foo a =,
-       --   Foo a Int
-       --   deriving (Show, Eq, Ord),
-       (l + 1) == l') &&
-      tagText t == tagText t'
-      where
-        SrcPos f  l  = posOf t
-        SrcPos f' l' = posOf t'
+      posOf t   == posOf t'   &&
+      tagText t == tagText t' &&
+      tagType t == tagType t'
 
 combineBalanced :: forall a. (a -> a -> a) -> [a] -> a
 combineBalanced f xs = go xs

--- a/src/FastTags.hs
+++ b/src/FastTags.hs
@@ -601,7 +601,9 @@ functionTagsNoSig toks = go toks
     go toks@(Pos _ (Token _ "("):_) = go $ stripBalancedParens toks
     go (Pos pos (Token prefix name):ts)
       | name == "::"               = [] -- this function does not analyze type signatures
-      | name == "!" || name == "~" = go ts
+      | name == "!" ||
+        name == "~" ||
+        name == "@"                = go ts
       | name == "=" || name == "|" =
         case stripParens toks of
           Pos pos (Token prefix name): _

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -41,8 +41,6 @@ main = do
                                in usage $ errMsg ++ "\n" ++ help
 
     when (Help `elem` flags) $ usage help
-    when (null inputs) $
-        usage "no input files\n"
 
     let verbose       = Verbose `elem` flags
         emacs         = ETags `elem` flags
@@ -77,6 +75,8 @@ main = do
                         -- for now
 
     inputs <- inputsM
+    when (null inputs) $
+        usage "no input files on either command line or stdin\n"
     -- This will merge and sort the new tags.  But I don't run it on the
     -- the result of merging the old and new tags, so tags from another
     -- file won't be sorted properly.  To do that I'd have to parse all the

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -419,7 +419,6 @@ testFunctions = testGroup "functions"
 
   , "_g :: X -> Y" ==> ["_g"]
   , toplevelFunctionsWithoutSignatures
-  , toplevelFunctionsWithoutSignatures
   ]
   where
     (==>) = test process
@@ -442,6 +441,7 @@ testFunctions = testGroup "functions"
         , "(:*:) ((:+:) x y) z = x" ==> [":*:"]
         , strictMatchTests
         , lazyMatchTests
+        , atPatternsTests
         , "f x Nothing = x\n\
           \f x (Just y) = y"
           ==>
@@ -494,6 +494,24 @@ testFunctions = testGroup "functions"
       -- this is a degenerate case since even ghc treats ~ here as
       -- a BangPatterns instead of operator
       , "x ~ y = x" ==> ["x"]
+      ]
+    atPatternsTests = testGroup "at patterns (@)"
+      [ "f z@x y    = z"              ==> ["f"]
+      , "f x   z'@y = z'"             ==> ["f"]
+      , "f z@x z'@y = z"              ==> ["f"]
+      , "f z@(Foo _) z'@y = z"        ==> ["f"]
+      , "f z@(Foo _) z'@(Bar _) = z"  ==> ["f"]
+      , "f z @ x y  = z"              ==> ["f"]
+      , "f z @ (x : xs) = z: [x: xs]" ==> ["f"]
+      , "f z @ (x : zs @ xs) = z: [x: zs]"      ==> ["f"]
+      , "f z @ (zz @x : zs @ xs) = z: [zz: zs]" ==> ["f"]
+
+      , "(:*:) zzz@(x :+: y) z = x"            ==> [":*:"]
+      , "(:*:) zzz@(zx@x :+: zy@y) zz@z = x"   ==> [":*:"]
+      , "(:*:) zzz@((:+:) x y) z = x"          ==> [":*:"]
+      , "(:*:) zzz@((:+:) zs@x zs@y) zz@z = x" ==> [":*:"]
+
+      , "f z@(!x) ~y = x"              ==> ["f"]
       ]
 
 testClass :: TestTree

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -119,13 +119,13 @@ testProcessAll = testGroup "processAll"
      \data X"]       ==> ["fn0:2 X Type", "fn0:1 X Module"]
   -- Extra X was filtered.
   , ["module X\n\
-     \data X = X\n"] ==> ["fn0:2 X Type", "fn0:1 X Module"]
+     \data X = X\n"] ==> ["fn0:2 X Type", "fn0:2 X Constructor", "fn0:1 X Module"]
   , ["module X\n\
      \data X a =\n\
-     \  X a\n"] ==> ["fn0:2 X Type", "fn0:1 X Module"]
+     \  X a\n"] ==> ["fn0:2 X Type", "fn0:3 X Constructor", "fn0:1 X Module"]
   , ["newtype A f a b = A\n\
      \  { unA :: f (a -> b) }"]
-    ==> ["fn0:1 A Type", "fn0:2 unA Function"]
+    ==> ["fn0:1 A Type", "fn0:1 A Constructor", "fn0:2 unA Function"]
   ]
   where
     (==>) = test f


### PR DESCRIPTION
Hi, this is followup to https://github.com/elaforge/fast-tags/pull/6. It includes fixing of sorting so that two `AttributeMap` tags, constructor and type name, will be detected in the following code snippet

```Haskell
newtype AttributeMap =
    AttributeMap [(Score.Attributes, [Keyswitch], Maybe Keymap)]
    deriving (Eq, Show, Pretty.Pretty, DeepSeq.NFData)
```

The handling of at patterns was also fixed, now they're not confused for operators.

I also added instances of `NFData` for tags since they're convenient for benchmarks and clients of the fast-tags library (of which there's only me but nonetheless), do not impose external dependencies as `deepseq` package is part of the platform and should not result in any overhead or executable size increase as they're not used by the actual fast-tags binary.

I also added .hsc files to candidates for tag collection since they're basically haskell files with some preprocessor-like extensions which are stripped away by fast-tags. Which means that .hsc files can be reliably handled by the fast-tags tool.

And the last change is fix of check for missing input files, which I messed up when merging my changes into the master.