### PR TITLE
Strip newlines before attempting to detect newtypes in instance declaration

### DIFF
--- a/src/FastTags.hs
+++ b/src/FastTags.hs
@@ -802,7 +802,7 @@ instanceTags :: SrcPos -> UnstrippedTokens -> [Tag]
 instanceTags prevPos unstripped =
     -- instances can offer nothing but some fresh data constructors since
     -- the actual datatype is really declared in the class declaration
-    concatMap (newtypeTags prevPos . unstrippedTokensOf)
+    concatMap (newtypeTags prevPos . stripNewlines)
         (filter isNewtypeDecl block)
     ++ concatMap (dataConstructorTags prevPos)
         (filter isDataDecl block)

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -600,6 +600,16 @@ testInstance = testGroup "instance"
     \  newtype Bar Quux a = QBar { frob :: a }"
     ==>
     ["QBar", "frob"]
+  , "instance (Monoid w,MonadBaseControl b m) => MonadBaseControl b (JournalT w m) where\n\
+    \   newtype StM (JournalT w m) a =\n\
+    \       StMJournal { unStMJournal :: ComposeSt (JournalT w) m a }\n\
+    \   liftBaseWith = defaultLiftBaseWith StMJournal\n\
+    \   restoreM     = defaultRestoreM   unStMJournal\n\
+    \   {-# INLINE liftBaseWith #-}\n\
+    \   {-# INLINE restoreM #-}\n\
+    \"
+    ==>
+    ["StMJournal", "unStMJournal"]
   ]
   where
     (==>) = test process


### PR DESCRIPTION
Please see test case for the example where this may come in handy. Currently a warning will reported to the user about unexpected newline token.