### PR TITLE
add some concurrency

### DIFF
--- a/fast-tags.cabal
+++ b/fast-tags.cabal
@@ -64,12 +64,13 @@ executable fast-tags
     main-is: src/Main.hs
     build-depends:
         base >= 3 && < 5, containers, filepath, directory,
+        async,
         -- text 0.11.1.12 has a bug.
         text (> 0.11.1.12 || < 0.11.1.12),
         bytestring,
         fast-tags
-    ghc-options: -Wall -fno-warn-name-shadowing
-    ghc-prof-options: -Wall -fno-warn-name-shadowing -auto-all
+    ghc-options: -Wall -fno-warn-name-shadowing -threaded
+    ghc-prof-options: -Wall -fno-warn-name-shadowing -auto-all -threaded
     if flag(fast)
         ghc-options:
             -funfolding-creation-threshold=10000

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -9,6 +9,8 @@
 -}
 module Main (main) where
 import Control.Applicative
+import Control.Concurrent.Async (mapConcurrently)
+import Control.Concurrent.MVar (newMVar, takeMVar, putMVar)
 import Control.Monad
 import Data.Map (Map)
 import Data.Monoid
@@ -81,14 +83,17 @@ main = do
     -- file won't be sorted properly.  To do that I'd have to parse all the
     -- old tags and run processAll on all of them, which is a hassle.
     -- TODO try it and see if it really hurts performance that much.
+    printLock <- newMVar ()
     newTags <- fmap processAll $
-        forM (zip [0..] inputs) $ \(i :: Int, fn) -> do
+        flip mapConcurrently (zip [0..] inputs) $ \(i :: Int, fn) -> do
             (newTags, warnings) <- processFile fn trackPrefixes
+            -- takeMVar printLock
             forM_ warnings printErr
             when verbose $ do
                 let line = take 78 $ show i ++ ": " ++ fn
                 putStr $ '\r' : line ++ replicate (78 - length line) ' '
                 IO.hFlush IO.stdout
+            -- putMVar printLock ()
             return newTags
 
     when verbose $ putChar '\n'


### PR DESCRIPTION
I think we can improve the performance by adding some parallelism to it.

Current HEAD:

```
➜  ghc git:(master) ✗ /usr/bin/time -p fast-tags . -R         
./testsuite/tests/typecheck/should_compile/tc225.hs:7: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/T2126.hs:5: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/tcfail176.hs:7: unexpected end of block after newtype * =
real 9.19
user 8.95
sys 0.22
```

With this path, RTS options not set:

```
➜  ghc git:(master) ✗ /usr/bin/time -p fast-tags . -R
./testsuite/tests/typecheck/should_compile/tc225.hs:7: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/T2126.hs:5: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/tcfail176.hs:7: unexpected end of block after newtype * =
real 9.59
user 9.26
sys 0.32
```

With this patch, RTS options set:

```
➜  ghc git:(master) ✗ /usr/bin/time -p fast-tags . -R +RTS -N4
./testsuite/tests/typecheck/should_compile/tc225.hs:7: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/T2126.hs:5: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/tcfail176.hs:7: unexpected end of block after newtype * =
real 4.64
user 12.81
sys 2.22
➜  ghc git:(master) ✗ /usr/bin/time -p fast-tags . -R +RTS -N5
./testsuite/tests/typecheck/should_compile/tc225.hs:7: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/T2126.hs:5: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/tcfail176.hs:7: unexpected end of block after newtype * =
real 4.60
user 15.68
sys 2.73
➜  ghc git:(master) ✗ /usr/bin/time -p fast-tags . -R +RTS -N6
./testsuite/tests/typecheck/should_compile/tc225.hs:7: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/T2126.hs:5: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/tcfail176.hs:7: unexpected end of block after newtype * =
real 4.70
user 18.55
sys 3.84
➜  ghc git:(master) ✗ /usr/bin/time -p fast-tags . -R +RTS -N7
./testsuite/tests/typecheck/should_compile/tc225.hs:7: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/T2126.hs:5: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/tcfail176.hs:7: unexpected end of block after newtype * =
real 4.73
user 21.51
sys 4.48
➜  ghc git:(master) ✗ /usr/bin/time -p fast-tags . -R +RTS -N8
./testsuite/tests/typecheck/should_compile/tc225.hs:7: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/T2126.hs:5: unexpected end of block after newtype * =
./testsuite/tests/typecheck/should_fail/tcfail176.hs:7: unexpected end of block after newtype * =
real 4.95
user 25.17
sys 5.75
```

One problem with this patch is that it isn't careful about printing; if threads print things at the same time output will be mingled. I tried adding MVars around printing part as a lock but unfortunately it was ridiculously slow. Any suggestions?
