### PR TITLE
Use tags format expected by vim

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -214,7 +214,7 @@ showTag :: Pos TagVal -> Text
 showTag (Pos (SrcPos fn lineno) (TagVal _ text typ)) = Text.concat
     [ text, "\t"
     , Text.pack fn, "\t"
-    , Text.pack (show lineno), " ;\" "
+    , Text.pack (show lineno), ";\"\t"
     , Text.singleton (showType typ)
     ]
 


### PR DESCRIPTION
What the docs at tags-file-format call {term}, i.e. the string ';"', has to follow {tagaddress} directly, with no space. {field}, on the other hand, includes an explicit &lt;tab>.