### PR TITLE
Implement new command line option to optionally skip module tags

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+1.1.2:
+
+* Implement `--no-module-tags` command line parameter to optionally avoid
+  tagging modules.
+
 1.1.1:
 
 * fix 'format' output for vim

--- a/fast-tags.cabal
+++ b/fast-tags.cabal
@@ -1,5 +1,5 @@
 name: fast-tags
-version: 1.1.1
+version: 1.1.2
 cabal-version: >= 1.8
 build-type: Simple
 synopsis: Fast incremental vi and emacs tags.

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -52,10 +52,12 @@ options =
         "do not merge tag files"
     , GetOpt.Option [] ["version"] (GetOpt.NoArg Version)
         "print current version"
+    , GetOpt.Option [] ["no-module-tags"] (GetOpt.NoArg NoModuleTags)
+        "do not generate tags for modules"
     ]
 
 data Flag = Output FilePath | Help | Verbose | ETags | Recurse | NoMerge
-    | ZeroSep | Version
+    | ZeroSep | Version | NoModuleTags
     deriving (Eq, Show)
 
 main :: IO ()
@@ -79,6 +81,7 @@ main = do
         trackPrefixes = emacs
         output        = last $ defaultOutput : [fn | Output fn <- flags]
         defaultOutput = if vim then "tags" else "TAGS"
+        filters       = if NoModuleTags `elem` flags then [noModuleTags] else []
 
     oldTags <- if vim && NoMerge `notElem` flags
         then do
@@ -98,7 +101,7 @@ main = do
     -- TODO try it and see if it really hurts performance that much.
     newTags <- fmap processAll $
         flip Async.mapConcurrently (zip [0..] inputs) $ \(i :: Int, fn) -> do
-            (newTags, warnings) <- processFile fn trackPrefixes
+            (newTags, warnings) <- processFile fn trackPrefixes filters
             mapM_ (IO.hPutStrLn IO.stderr) warnings
             when verbose $ do
                 let line = take 78 $ show i ++ ": " ++ fn

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -99,7 +99,7 @@ main = do
     newTags <- fmap processAll $
         flip Async.mapConcurrently (zip [0..] inputs) $ \(i :: Int, fn) -> do
             (newTags, warnings) <- processFile fn trackPrefixes
-            mapM_ (IO.hPutStrln IO.stderr) warnings
+            mapM_ (IO.hPutStrLn IO.stderr) warnings
             when verbose $ do
                 let line = take 78 $ show i ++ ": " ++ fn
                 putStr $ '\r' : line ++ replicate (78 - length line) ' '
@@ -151,7 +151,7 @@ getRecursiveDirContents :: FilePath -> IO [FilePath]
 getRecursiveDirContents topdir = do
     paths <- getProperDirContents topdir
     paths' <- forM paths $ \path -> do
-        isDirectory <- doesDirectoryExist path
+        isDirectory <- Directory.doesDirectoryExist path
         if isDirectory
             then getRecursiveDirContents path
             else return [path]


### PR DESCRIPTION
This is very useful for couple of reasons:

- In Haskell almost always module names and file names are the same, e.g. `module A.B.C` is in `A/B/C.hs` etc. This makes finding modules very easy and tags are usually not necessary.

- There's a very old bug that still effects my workflow: https://github.com/ctrlpvim/ctrlp.vim/issues/92 Because of this I need to be very careful with tags with same names. In Haskell we often have modules that define types with same names, e.g. `TypeRep.hs` defines the type `TypeRep` etc. This patch helps with avoiding the linked bug in these cases.