### PR TITLE
Add `alex` as required `build-tool` in `fast-tags.cabal`

### DIFF
--- a/fast-tags.cabal
+++ b/fast-tags.cabal
@@ -54,6 +54,7 @@ library
         deepseq,
         array,
         utf8-string
+    build-tools: alex
     exposed-modules: Control.Monad.EitherK
                      FastTags
                      Lexer


### PR DESCRIPTION
The main reason that I'm adding this is that this benefits Nix.  The `cabal2nix`
tool builds a Nix expression from the corresponding `fast-tags.cabal` file of a
Haskell project, and it requires this `build-tool: alex` field to know to add
`alex` as a project dependency.

This may or may not also help plain `cabal`-only builds, but it can't hurt.