### PR TITLE
Improve precision of tag analysis

### DIFF
--- a/fast-tags.cabal
+++ b/fast-tags.cabal
@@ -49,11 +49,6 @@ source-repository head
     type: git
     location: git://github.com/elaforge/fast-tags.git
 
-flag fast
-    description:
-        Spend more time optimizing a program (may yield up to 25% speedup)
-    default: False
-
 flag profile
     description: add -auto-all
     default: False
@@ -82,10 +77,6 @@ library
         FastTags.Util
     hs-source-dirs: src
     ghc-options: -Wall -fno-warn-name-shadowing
-    if flag(fast)
-        ghc-options:
-            -funfolding-creation-threshold=10000
-            -funfolding-use-threshold=2500
     if flag(profile)
         ghc-prof-options: -Wall -fno-warn-name-shadowing -auto-all
 
@@ -107,10 +98,6 @@ executable fast-tags
     -- library.
     ghc-options:
         -main-is FastTags.Main -Wall -fno-warn-name-shadowing -threaded
-    if flag(fast)
-        ghc-options:
-            -funfolding-creation-threshold=10000
-            -funfolding-use-threshold=2500
     if flag(profile)
         ghc-prof-options:
             -auto-all -Wall -fno-warn-name-shadowing -threaded

--- a/src/FastTags/Lexer.x
+++ b/src/FastTags/Lexer.x
@@ -81,6 +81,10 @@ $octdigit   = [0-7]
 $hexdigit   = [0-9a-fA-F]
 @charescape = [\\] ( $charesc | $asclarge+ | "o" $octdigit+ | "x" $hexdigit+ )
 
+@float_number =  ( [\+\-]? ( $digit+ ( "." $digit+ )? | $digit* "." $digit+ ) ( [eE] [\+\-]? $digit* )? )
+
+@number = ( [\+\-]? $digit+ | 0 ([oO] $octdigit+ | [xX] $hexdigit ) | @float_number )
+
 :-
 
 -- Can skip whitespace everywhere since it does not affect meaning in any
@@ -188,6 +192,10 @@ $space*                 { \input len -> endIndentationCounting len }
 ")"                     { popRParen }
 "~"                     { kw Tilde }
 ";"                     { kw Semicolon }
+
+-- Not interested in numbers, but it takes time to extract their text so
+-- it's quicker to just ignore them.
+@number                 { kw Number }
 
 @qualificationPrefix ( $ident+ | $symbol+ )
                         { \input len -> return $ T $ retrieveToken input len }

--- a/src/FastTags/Lexer.x
+++ b/src/FastTags/Lexer.x
@@ -119,16 +119,11 @@ $space*                 { \input len -> endIndentationCounting len }
 
 -- Strings
 <0> [\"]                { \_ _ -> startString }
-<string> [\"]           { \_ _ -> endString 0 }
-<string> [\\] $nl ( $ws+ [\\] )? ;
-<string> ( $ws+ | [^\"\\$nl] | [\\] . )+ ;
-
--- Strings
-<0> [\"]                { \_ _ -> startString }
-<string> [\\] [\"\\]    ;
-<string> [\\] $nl ($ws+ [\\])? ;
-<string> [\"]           { \_ _ -> endString 0 }
-<string> (. | $nl)      ;
+<string> ( [\\] [\r]? $nl $ws* [\\] ) ? [\"]
+                        { \_ _ -> endString 0 }
+<string> [\\] [\r]? $nl ( $ws* [\\] )? ;
+<string> ( $ws | [^ \" \\ $nl] )+ ;
+<string> ( . | $nl | [\\] . )     ;
 
 
 

--- a/src/FastTags/Lexer.x
+++ b/src/FastTags/Lexer.x
@@ -194,6 +194,8 @@ $space*                 { \input len -> endIndentationCounting len }
 "~"                     { kw Tilde }
 ";"                     { kw Semicolon }
 
+[\\]                    { kw LambdaBackslash }
+
 -- Not interested in numbers, but it takes time to extract their text so
 -- it's quicker to just ignore them.
 @number                 { kw Number }

--- a/src/FastTags/Lexer.x
+++ b/src/FastTags/Lexer.x
@@ -125,8 +125,6 @@ $space*                 { \input len -> endIndentationCounting len }
 <string> ( $ws | [^ \" \\ $nl] )+ ;
 <string> ( . | $nl | [\\] . )     ;
 
-
-
 -- Characters
 <0> [\'] ( [^\'\\] | @charescape ) [\'] { kw Character }
 

--- a/src/FastTags/Lexer.x
+++ b/src/FastTags/Lexer.x
@@ -119,8 +119,9 @@ $hexdigit   = [0-9a-fA-F]
 -- Template Haskell quasiquoters
 
 <0> "[" $ident* "|"     { \input len -> startQuasiquoter input len }
+<0> "⟦"                 { \_ _ -> startUnconditionalQuasiQuoter }
 <qq> "$("               { \_ _ -> startSplice CtxQuasiquoter }
-<qq> "|]"               { \_ _ -> endQuasiquoter 0 }
+<qq> ("|]" | "⟧")       { \_ _ -> endQuasiquoter 0 }
 <qq> (. | $nl)          ;
 
 <0> "$("                { \_ _ -> startSplice CtxHaskell }

--- a/src/FastTags/Lexer.x
+++ b/src/FastTags/Lexer.x
@@ -137,7 +137,8 @@ $space*                 { \input len -> endIndentationCounting len }
 
 -- Template Haskell quasiquoters
 
-<0> "[" $ident* "|"     { \input len -> startQuasiquoter input len }
+<0> "[" [\$\(]* @qualificationPrefix $ident* [\)]*  "|"
+                        { \input len -> startQuasiquoter input len }
 <0> "⟦"                 { \_ _ -> startUnconditionalQuasiQuoter }
 <qq> "$("               { \_ _ -> startSplice CtxQuasiquoter }
 <qq> ("|]" | "⟧")       { \_ _ -> endQuasiquoter 0 }
@@ -197,7 +198,9 @@ $space*                 { \input len -> endIndentationCounting len }
 -- it's quicker to just ignore them.
 @number                 { kw Number }
 
-@qualificationPrefix ( $ident+ | $symbol+ )
+[\']* @qualificationPrefix ($ident | $large)+
+                        { \input len -> return $ T $ retrieveToken input len }
+@qualificationPrefix $symbol+
                         { \input len -> return $ T $ retrieveToken input len }
 
 }

--- a/src/FastTags/Lexer.x
+++ b/src/FastTags/Lexer.x
@@ -84,7 +84,7 @@ $hexdigit   = [0-9a-fA-F]
 
 <0> {
 
-$nl $space*             { \_ len -> pure $ Newline $ len - 1 }
+[\\]? $nl $space*       { \_ len -> pure $ Newline $ len - 1 }
 [\-][\-]+ ~[$symbol $nl] .* ;
 [\-][\-]+ / $nl         ;
 

--- a/src/FastTags/LexerTypes.hs
+++ b/src/FastTags/LexerTypes.hs
@@ -152,6 +152,7 @@ calculateQuasiQuoteEnds startPos =
         , qqessMap      =
               case (qqessPrevChar, c) of
                   ('|', ']') -> IS.insert qqessPos qqessMap
+                  (_,   '⟧') -> IS.insert qqessPos qqessMap
                   _          -> qqessMap
         , qqessPrevChar = c
         }

--- a/src/FastTags/LexerTypes.hs
+++ b/src/FastTags/LexerTypes.hs
@@ -123,18 +123,11 @@ mkAlexState input = AlexState
     , asPositionsOfQuasiQuoteEnds = Nothing
     }
 
+{-# INLINE pushContext #-}
 pushContext :: (MonadState AlexState m) => Context -> m ()
 pushContext ctx = modify (\s -> s { asContextStack = ctx : asContextStack s })
 
-popContext :: (MonadState AlexState m, MonadError String m) => m Context
-popContext = do
-    cs <- gets asContextStack
-    case cs of
-        []      -> throwError "Popping empty context stack"
-        c : cs' -> do
-            modify $ \s -> s { asContextStack = cs' }
-            return c
-
+{-# INLINE modifyCommentDepth #-}
 modifyCommentDepth :: (MonadState AlexState m) => (Int -> Int) -> m Int
 modifyCommentDepth f = do
     depth <- gets asCommentDepth
@@ -142,6 +135,7 @@ modifyCommentDepth f = do
     modify $ \s -> s { asCommentDepth = depth' }
     return depth'
 
+{-# INLINE modifyQuasiquoterDepth #-}
 modifyQuasiquoterDepth :: (MonadState AlexState m) => (Int -> Int) -> m Int
 modifyQuasiquoterDepth f = do
     depth <- gets asQuasiquoterDepth
@@ -152,6 +146,7 @@ modifyQuasiquoterDepth f = do
 retrieveToken :: AlexInput -> Int -> Text
 retrieveToken (AlexInput {aiInput}) len = Text.take len aiInput
 
+{-# INLINE addIndentationSize #-}
 addIndentationSize :: (MonadState AlexState m) => Int -> m ()
 addIndentationSize x =
     modify (\s -> s { asIndentationSize = x + asIndentationSize s })
@@ -185,9 +180,11 @@ runAlexM trackPrefixes input action =
     where
     s = mkAlexState $ mkAlexInput input trackPrefixes
 
+{-# INLINE alexSetInput #-}
 alexSetInput :: (MonadState AlexState m) => AlexInput -> m ()
 alexSetInput input = modify $ \s -> s { asInput = input }
 
+{-# INLINE alexSetStartCode #-}
 alexSetStartCode :: (MonadState AlexState m) => Int -> m ()
 alexSetStartCode code = modify $ \s -> s { asCode = code }
 

--- a/src/FastTags/LexerTypes.hs
+++ b/src/FastTags/LexerTypes.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP               #-}
 {-# LANGUAGE ConstraintKinds   #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE NamedFieldPuns    #-}
@@ -8,11 +7,6 @@ module FastTags.LexerTypes where
 
 import Codec.Binary.UTF8.String (encodeChar)
 import Control.Applicative
-#if MIN_VERSION_mtl(2,2,0)
-import Control.Monad.Except
-#else
-import Control.Monad.Error
-#endif
 import Control.Monad.State.Strict
 import Data.Char
 import Data.IntSet (IntSet)

--- a/src/FastTags/LexerTypes.hs
+++ b/src/FastTags/LexerTypes.hs
@@ -16,7 +16,7 @@ import Control.Monad.Error
 import Control.Monad.State.Strict
 import Data.Char
 import Data.IntSet (IntSet)
-import qualified Data.IntSet as IS
+import qualified Data.IntSet as IntSet
 import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -159,15 +159,15 @@ data QQEndsState = QQEndsState
 
 calculateQuasiQuoteEnds :: Int -> Text -> IntSet
 calculateQuasiQuoteEnds startPos =
-    qqessMap . Text.foldl' combine (QQEndsState startPos mempty '\n')
+    qqessMap . Text.foldl' combine (QQEndsState startPos IntSet.empty '\n')
     where
     combine :: QQEndsState -> Char -> QQEndsState
     combine QQEndsState{qqessPos, qqessMap, qqessPrevChar} c = QQEndsState
         { qqessPos      = qqessPos + 1
         , qqessMap      =
               case (qqessPrevChar, c) of
-                  ('|', ']') -> IS.insert qqessPos qqessMap
-                  (_,   '⟧') -> IS.insert qqessPos qqessMap
+                  ('|', ']') -> IntSet.insert qqessPos qqessMap
+                  (_,   '⟧') -> IntSet.insert qqessPos qqessMap
                   _          -> qqessMap
         , qqessPrevChar = c
         }

--- a/src/FastTags/Main.hs
+++ b/src/FastTags/Main.hs
@@ -195,7 +195,7 @@ main = do
 
 typeOf :: Token.Pos Tag.TagVal -> Tag.Type
 typeOf tagVal = case Token.valOf tagVal of
-    Tag.TagVal _ typ -> typ
+    Tag.TagVal _ typ _ -> typ
 
 -- | Expand file inputs from cmdline.
 getInputs :: [Flag] -> [FilePath] -> IO [FilePath]

--- a/src/FastTags/Tag.hs
+++ b/src/FastTags/Tag.hs
@@ -771,7 +771,11 @@ dataConstructorTags prevPos unstripped
             stripBalancedParens input
         stripTypeParam input@(Pos _ LBracket : _) =
             stripBalancedBrackets input
-        stripTypeParam ts = drop 1 ts
+        stripTypeParam ts = dropWhile isTypeParam $ drop 1 ts
+
+        isTypeParam :: Token -> Bool
+        isTypeParam (Pos _ (T name)) = isTypeVarStart name
+        isTypeParam _                = False
 
     dropUntilNextCaseOrRecordStart :: [Token] -> [Token]
     dropUntilNextCaseOrRecordStart = dropWithStrippingBalanced $

--- a/src/FastTags/Tag.hs
+++ b/src/FastTags/Tag.hs
@@ -397,6 +397,7 @@ explodeToplevelBracedBlocks toks =
 blockTags :: UnstrippedTokens -> [Tag]
 blockTags unstripped = case stripNewlines unstripped of
     [] -> []
+    Pos _ SpliceStart : _ -> []
     Pos _ KWModule : Pos pos (T name) : _ ->
         [mkTag pos (snd (T.breakOnEnd "." name)) Module]
     stripped@(Pos _       (T "pattern") : Pos _ DoubleColon : _) ->

--- a/src/FastTags/Tag.hs
+++ b/src/FastTags/Tag.hs
@@ -716,10 +716,10 @@ dataConstructorTags prevPos unstripped
     strip = stripOptBang . stripDatatypeContext . dropUntil Equals
           . stripNewlines
     collectRest :: [Token] -> [Tag]
-    collectRest toks@(Pos _ LParen : _) = collectRest $ stripBalancedParens toks -- dropUntilNextField rest
     collectRest tokens
         | (tags@(_:_), rest) <- functionTags ExpectFunctions tokens =
             tags ++ collectRest (dropUntilNextField rest)
+    collectRest toks@(Pos _ LParen : _) = collectRest $ stripBalancedParens toks -- dropUntilNextField rest
     collectRest (Pos pipePos Pipe : rest)
         | Just (Pos pos (T name), rest'') <- extractInfixConstructor rest' =
             mkTag pos name Constructor : collectRest rest''

--- a/src/FastTags/Tag.hs
+++ b/src/FastTags/Tag.hs
@@ -322,17 +322,22 @@ breakBlock = go []
             _            -> n
 
 stripSemicolonsNotInBraces :: [Token] -> [Token]
-stripSemicolonsNotInBraces = go False 0 0
+stripSemicolonsNotInBraces =
+    go False 0 0
   where
-    go  :: Bool -- Whether inside where block or after equals sign
+    go  :: Bool -- Whether inside let or where block or case expression
         -> Int -- Indent of last newline
         -> Int -- Parenthesis nesting depth
         -> [Token]
         -> [Token]
     go !_     !_ !_ []                                                       = []
+    go !b     !k !n (tok@(Pos _ KWWhere)     : tok'@(Pos _ LBrace) : ts)     = tok : tok' : skipBalancedParens b k (inc n) ts
     go !_     !k !n (tok@(Pos _ KWWhere)     : ts)                           = tok : go True k n ts
+    go !b     !k !n (tok@(Pos _ KWLet)       : tok'@(Pos _ LBrace) : ts)     = tok : tok' : skipBalancedParens b k (inc n) ts
     go !_     !k !n (tok@(Pos _ KWLet)       : ts)                           = tok : go True k n ts
+    go !b     !k !n (tok@(Pos _ KWDo)        : tok'@(Pos _ LBrace) : ts)     = tok : tok' : skipBalancedParens b k (inc n) ts
     go !_     !k !n (tok@(Pos _ KWDo)        : ts)                           = tok : go True k n ts
+    go !b     !k !n (tok@(Pos _ KWOf)        : tok'@(Pos _ LBrace) : ts)     = tok : tok' : skipBalancedParens b k (inc n) ts
     go !_     !k !n (tok@(Pos _ KWOf)        : ts)                           = tok : go True k n ts
     go !_     !k !n (tok@(Pos _ KWIn)        : ts)                           = tok : go False k n ts
     go !_     !_ !n (tok@(Pos _ (Newline k)) : ts)                           = tok : go False k n ts

--- a/src/FastTags/Tag.hs
+++ b/src/FastTags/Tag.hs
@@ -670,13 +670,12 @@ stripOptContext origToks = go origToks
 -- | Drop all tokens for which @pred@ returns True, also drop () or []
 -- parenthesized expressions.
 dropWithStrippingBalanced :: (TokenVal -> Bool) -> [Token] -> [Token]
-dropWithStrippingBalanced p input@(Pos _ LParen : _) =
-    dropWithStrippingBalanced p $ stripBalancedParens input
-dropWithStrippingBalanced p input@(Pos _ LBracket : _) =
-    dropWithStrippingBalanced p $ stripBalancedBrackets input
-dropWithStrippingBalanced p (Pos _ tok : xs)
-    | p tok  = dropWithStrippingBalanced p xs
-dropWithStrippingBalanced _ xs = xs
+dropWithStrippingBalanced p = go
+    where
+    go input@(Pos _ LParen : _)   = go $ stripBalancedParens input
+    go input@(Pos _ LBracket : _) = go $ stripBalancedBrackets input
+    go (Pos _ tok : xs) | p tok   = go xs
+    go xs = xs
 
 stripBalancedParens :: [Token] -> [Token]
 stripBalancedParens = stripBalanced LParen RParen

--- a/src/FastTags/Tag.hs
+++ b/src/FastTags/Tag.hs
@@ -477,6 +477,8 @@ functionTagsNoSig allToks = go allToks
     where
     go :: [Token] -> [Tag]
     go []                           = []
+    go (Pos _ LParen : Pos _ T{} : Pos _ Backtick : Pos pos' (T name') : Pos _ Backtick : Pos _ T{} : Pos _ RParen : _)
+        | functionName ExpectFunctions name' = [mkRepeatableTag pos' name' Function]
     go toks@(Pos _ LParen : _)      = go $ stripBalancedParens toks
     -- This function does not analyze type signatures.
     go (Pos _ DoubleColon : _)      = []

--- a/src/FastTags/Tag.hs
+++ b/src/FastTags/Tag.hs
@@ -488,6 +488,7 @@ recordVanillaOrInfixName
 recordVanillaOrInfixName isVanillaName tokenType prevPos context tokens =
     case dropDataContext tokens of
         Pos _ LParen   : Pos _ RParen : _ -> (Nothing, prevPos, tokens)
+        Pos _ RParen   : _                -> (Nothing, prevPos, tokens)
         Pos _ LBracket : _                -> (Nothing, prevPos, tokens)
         Pos _ Equals   : _                -> (Nothing, prevPos, tokens)
         Pos _ Comma    : _                -> (Nothing, prevPos, tokens)

--- a/src/FastTags/Tag.hs
+++ b/src/FastTags/Tag.hs
@@ -70,7 +70,15 @@ instance NFData TagVal where
 -- interest.
 --
 -- We rely that Type < Constructor.  TODO how and where?  For sorting tags?
-data Type = Function | Type | Constructor | Class | Module | Operator | Pattern
+data Type =
+    Function
+    | Type
+    | Constructor
+    | Class
+    | Module
+    | Operator
+    | Pattern
+    | Family
     deriving (Eq, Ord, Show)
 
 instance NFData Type where
@@ -312,7 +320,7 @@ blockTags unstripped = case stripNewlines unstripped of
     -- type family X ...
     Pos prevPos KWType : Pos _ KWFamily : toks -> maybeToList tag
         where
-        (tag, _,  _) = recordVanillaOrInfixName isTypeFamilyName Type prevPos
+        (tag, _,  _) = recordVanillaOrInfixName isTypeFamilyName Family prevPos
             "type family * =" toks
     -- type instance X * = ...
     -- No tags in type family instances
@@ -325,7 +333,7 @@ blockTags unstripped = case stripNewlines unstripped of
     -- data family X ...
     Pos prevPos KWData : Pos _ KWFamily : toks -> maybeToList tag
         where
-        (tag, _, _) = recordVanillaOrInfixName isTypeFamilyName Type prevPos
+        (tag, _, _) = recordVanillaOrInfixName isTypeFamilyName Family prevPos
             "data family * =" toks
     -- data instance * = ...
     -- data instance * where ...
@@ -696,8 +704,8 @@ stripUntilImplies xs =
 
 classBodyTags :: UnstrippedTokens -> [Tag]
 classBodyTags unstripped = case stripNewlines unstripped of
-    Pos _ KWType : Pos pos (T name) : _ -> [mkTag pos name Type]
-    Pos _ KWData : Pos pos (T name) : _ -> [mkTag pos name Type]
+    Pos _ KWType : Pos pos (T name) : _ -> [mkTag pos name Family]
+    Pos _ KWData : Pos pos (T name) : _ -> [mkTag pos name Family]
     tokens                              -> fst $ functionTags False tokens
 
 -- | Skip to the where and split the indented block below it.

--- a/src/FastTags/Token.hs
+++ b/src/FastTags/Token.hs
@@ -91,6 +91,8 @@ data TokenVal =
     | String
     -- | Actual character not tracked since it's irrelevant.
     | Character
+    -- | Actual value not tracked since it's irrelevant.
+    | Number
     | QuasiquoterStart
     | QuasiquoterEnd
     | SpliceStart -- \$(

--- a/src/FastTags/Token.hs
+++ b/src/FastTags/Token.hs
@@ -96,6 +96,7 @@ data TokenVal =
     | QuasiquoterStart
     | QuasiquoterEnd
     | SpliceStart -- \$(
+    | LambdaBackslash -- \
     | EOF
     deriving (Show, Eq, Ord)
 

--- a/src/FastTags/Token.hs
+++ b/src/FastTags/Token.hs
@@ -83,6 +83,7 @@ data TokenVal =
     | RBracket
     | RParen
     | Tilde
+    | Semicolon
     | T !Text
     -- | Special token, not part of Haskell spec. Stores indentation.
     | Newline !Int

--- a/src/FastTags/Vim.hs
+++ b/src/FastTags/Vim.hs
@@ -111,6 +111,7 @@ toType typ = case typ of
     Tag.Constructor -> 'C'
     Tag.Operator    -> 'o'
     Tag.Pattern     -> 'p'
+    Tag.Family      -> 'F'
 
 fromType :: Char -> Maybe Tag.Type
 fromType c = case c of
@@ -121,4 +122,5 @@ fromType c = case c of
     'C' -> Just Tag.Constructor
     'o' -> Just Tag.Operator
     'p' -> Just Tag.Pattern
+    'F' -> Just Tag.Family
     _ -> Nothing

--- a/src/FastTags/Vim.hs
+++ b/src/FastTags/Vim.hs
@@ -92,7 +92,7 @@ vimMagicLine = "!_TAG_FILE_SORTED\t1\t//"
 
 -- | Convert a Tag to text, e.g.: AbsoluteMark\tCmd/TimeStep.hs 67 ;" f
 showTag :: Token.Pos Tag.TagVal -> Text
-showTag (Token.Pos pos (Tag.TagVal text typ)) = mconcat
+showTag (Token.Pos pos (Tag.TagVal text typ _)) = mconcat
     [ text, "\t"
     , Text.pack (Token.posFile pos), "\t"
     , Text.pack (show $ Token.unLine (Token.posLine pos)), ";\"\t"

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -745,6 +745,28 @@ testData = testGroup "data"
     , "data IO a = IO (World->(a,World))"
       ==>
       ["IO", "IO"]
+
+    , "data SubTransformTriple a =\n\
+      \        SubTransformTriple\n\
+      \           (forall sh. (Shape sh, Slice sh) => Transform (sh:.Int) a)\n\
+      \           (forall sh. (Shape sh, Slice sh) => Transform (sh:.Int) a)\n\
+      \           (forall sh. (Shape sh, Slice sh) => Transform (sh:.Int) a)"
+      ==>
+      ["SubTransformTriple", "SubTransformTriple"]
+
+    , "data TestCase \n\
+      \    = forall a prop . (Testable prop, Data a) \n\
+      \    => TestCase  (((String, a, a) -> Property) -> prop)\n\
+      \        deriving (Typeable)"
+      ==>
+      ["TestCase", "TestCase"]
+
+    , "-- | Binding List\n\
+      \data BindingList v a = Variable v => BindingList {source :: Source v a -- ^ the list's binding source\n\
+      \                                                , list   :: v [v a]    -- ^ the bound list\n\
+      \                                                , pos    :: v Int}     -- ^ the current position"
+      ==>
+      ["BindingList", "BindingList", "list", "pos", "source"]
     ]
     where
     (==>) = testTagNames filename
@@ -1003,6 +1025,16 @@ testFunctions = testGroup "functions"
       \showComplexFloat x y = (showFFloat Nothing x \"\") ++ (if y > 0 then \"+\" else \"\") ++ (showFFloat Nothing y \"i\")"
       ==>
       ["showComplexFloat"]
+
+    , "createAlert            :<|>\n\
+      \ getAlert              :<|>\n\
+      \ deleteAlert           :<|>\n\
+      \ setAlertStatus        :<|>\n\
+      \ tagAlert              :<|>\n\
+      \ untagAlert            :<|>\n\
+      \ updateAlertAttributes = client (Proxy :: Proxy AlertApi)"
+      ==>
+      ["createAlert"]
 
     , "_g :: X -> Y" ==> ["_g"]
     , "(f . g) x = f (g x)" ==> ["."]

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -1001,6 +1001,7 @@ testFunctions = testGroup "functions"
           ["foo"]
         -- Functions named "pattern"
         , "pattern :: Int -> String -> [Int]"           ==> ["pattern"]
+        , "pattern x () = x + x"                        ==> ["pattern"]
         , "pattern, foo :: Int -> String -> [Int]"      ==> ["foo", "pattern"]
         , "foo, pattern :: Int -> String -> [Int]"      ==> ["foo", "pattern"]
         , "foo, pattern, bar :: Int -> String -> [Int]" ==> ["bar", "foo", "pattern"]

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -108,7 +108,7 @@ testTokenize = testGroup "tokenize"
     , "foo \"bar\\\n\
       \  \\bar\" baz"     ==> [T "foo", String, T "baz", Newline 0]
     , "(\\err -> case err of Foo -> True; _ -> False)" ==>
-        [ LParen, T "\\", T "err", Arrow, KWCase, T "err", KWOf, T "Foo"
+        [ LParen, LambdaBackslash, T "err", Arrow, KWCase, T "err", KWOf, T "Foo"
         , Arrow, T "True", Semicolon, T "_", Arrow, T "False", RParen, Newline 0
         ]
     , "foo = \"foo\\n\\\n\
@@ -152,6 +152,23 @@ testTokenize = testGroup "tokenize"
     , "--:+: :+: :+:"
       ==>
       [T "--:+:", T ":+:", T ":+:", Newline 0]
+
+    , "\\x -> y" ==> [LambdaBackslash, T "x", Arrow, T "y", Newline 0]
+    , "precalcClosure0 :: Grammar -> Name -> RuleList\n\
+      \precalcClosure0 g = \n\
+      \\\n -> case lookup n info' of\n\
+      \\tNothing -> []\n\
+      \\tJust c  -> c\n\
+      \  where"
+      ==>
+      [ T "precalcClosure0", DoubleColon, T "Grammar", Arrow, T "Name", Arrow, T "RuleList", Newline 0
+      , T "precalcClosure0", T "g", Equals, Newline 0
+      , LambdaBackslash, T "n", Arrow, KWCase, T "lookup", T "n", T "info'", KWOf, Newline 1
+      , T "Nothing", Arrow, LBracket, RBracket, Newline 1
+      , T "Just", T "c", Arrow, T "c", Newline 2
+      , KWWhere, Newline 0
+      ]
+
     , tokenizeSplices
     ]
     where
@@ -1261,6 +1278,14 @@ testLiterate = testGroup "literate"
       \\tm :: a->b\n\tn :: c\n\\end{code}"
       ==>
       ["C", "m", "n"]
+    , "> precalcClosure0 :: Grammar -> Name -> RuleList\n\
+      \> precalcClosure0 g = \n\
+      \>\t\\n -> case lookup n info' of\n\
+      \>\t\tNothing -> []\n\
+      \>\t\tJust c  -> c\n\
+      \>  where"
+      ==>
+      ["precalcClosure0"]
     ]
     where
     (==>) = test f

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -149,6 +149,9 @@ testTokenize = testGroup "tokenize"
     , "deriveJSON defaultOptions ''CI.CI"
       ==>
       [T "deriveJSON", T "defaultOptions", T "''CI.CI", Newline 0]
+    , "--:+: :+: :+:"
+      ==>
+      [T "--:+:", T ":+:", T ":+:", Newline 0]
     , tokenizeSplices
     ]
     where

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -667,6 +667,8 @@ testFunctions = testGroup "functions"
       ==>
       ["assertDataFormatError"]
 
+    , "(r `mkQ` br) a = _" ==> ["mkQ"]
+
     , "_g :: X -> Y"    ==> ["_g"]
     , toplevelFunctionsWithoutSignatures
     ]

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -176,6 +176,8 @@ testTokenize = testGroup "tokenize"
       ]
 
     , tokenizeSplices
+    , "import Foo hiding (Bar)" ==>
+      [KWImport, T "Foo", T "hiding", LParen, T "Bar", RParen, Newline 0]
     ]
     where
     (==>) = test f

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -107,19 +107,25 @@ testTokenize = testGroup "tokenize"
     -- multiline string
     , "foo \"bar\\\n\
       \  \\bar\" baz"     ==> [T "foo", String, T "baz", Newline 0]
+    -- multiline string with \r
+    , "foo \"bar\\\r\n\
+      \  \\bar\" baz"     ==> [T "foo", String, T "baz", Newline 0]
+    -- multiline string with zero indentation
+    , "foo \"bar\\\r\n\
+      \\\bar\" baz"     ==> [T "foo", String, T "baz", Newline 0]
     , "(\\err -> case err of Foo -> True; _ -> False)" ==>
         [ LParen, LambdaBackslash, T "err", Arrow, KWCase, T "err", KWOf, T "Foo"
         , Arrow, T "True", Semicolon, T "_", Arrow, T "False", RParen, Newline 0
         ]
-    , "foo = \"foo\\n\\\n\
+    , "foo = \"foo\\n\\\r\n\
       \  \\\" bar" ==> [T "foo", Equals, String, T "bar", Newline 0]
     , "foo = \"foo\\n\\\n\
       \  \\x\" bar" ==>
         [ T "foo", Equals, String, T "bar", Newline 0]
 
-    , "{-   ___   -}import Data.Char;main=putStr$do{c<-\"/1 AA A A;9+ )11929 )1191A 2C9A \";e\n\
-      \ {- {- | -} -}  {- {- || -} -}{- {- || -} -}{- {- || -} -} {--}.(`divMod`8).(+(-32)).ord$c};f(0,0)=\"\n\";f(m,n)=m?\"  \"++n?\"_/\"\n\
-      \{- {- | -} -}n?x=do{[1..n];x}                                    --- obfuscated\n\
+    , "{-   ___   -}import Data.Char;main=putStr$do{c<-\"/1 AA A A;9+ )11929 )1191A 2C9A \";e\r\n\
+      \ {- {- | -} -}  {- {- || -} -}{- {- || -} -}{- {- || -} -} {--}.(`divMod`8).(+(-32)).ord$c};f(0,0)=\"\n\";f(m,n)=m?\"  \"++n?\"_/\"\r\n\
+      \{- {- | -} -}n?x=do{[1..n];x}                                    --- obfuscated\r\n\
       \{-\\_/ on Fairbairn, with apologies to Chris Brown. Above is / Haskell 98 -}"
       ==>
       [ KWImport, T "Data.Char", Semicolon

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -660,6 +660,13 @@ testFunctions = testGroup "functions"
     , "(--+) :: X -> Y" ==> ["--+"]
     , "(=>>) :: X -> Y" ==> ["=>>"]
 
+    , "assertDataFormatError :: DecompressError -> IO String\n\
+      \assertDataFormatError (DataFormatError detail) = return detail\n\
+      \assertDataFormatError _                        = assertFailure \"expected DataError\"\n\
+      \                                              >> return \"\"\n"
+      ==>
+      ["assertDataFormatError"]
+
     , "_g :: X -> Y"    ==> ["_g"]
     , toplevelFunctionsWithoutSignatures
     ]

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -805,6 +805,19 @@ testData = testGroup "data"
       \    | EmptyR"
       ==>
       [":>", "EmptyR", "ViewR"]
+
+    , "data [] a = [] | a : [a]"
+      ==> [":", "[]", "[]"]
+    , "data () = ()"
+      ==> ["()", "()"]
+    , "data (,) a b = (,) a b"
+      ==> ["(,)", "(,)"]
+    , "data (,,) a b c = (,,) a b c"
+      ==> ["(,,)", "(,,)"]
+    , "data (a, b) = (a, b)"
+      ==> ["(,)", "(,)"]
+    , "data (a, b, c) = (a, b, c)"
+      ==> ["(,,)", "(,,)"]
     ]
     where
     (==>) = testTagNames filename

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -146,11 +146,23 @@ testTokenize = testGroup "tokenize"
             [ SpliceStart, T "foo", QuasiquoterStart, QuasiquoterEnd, RParen
             , Newline 0
             ]
+        , "$(foo ⟦ baz ⟧)"                    ==>
+            [ SpliceStart, T "foo", QuasiquoterStart, QuasiquoterEnd, RParen
+            , Newline 0
+            ]
         , "$(foo [bar| baz |])"                 ==>
             [ SpliceStart, T "foo", QuasiquoterStart, QuasiquoterEnd, RParen
             , Newline 0
             ]
+        , "$(foo [bar| baz ⟧)"                 ==>
+            [ SpliceStart, T "foo", QuasiquoterStart, QuasiquoterEnd, RParen
+            , Newline 0
+            ]
         , "$(foo [bar| bar!\nbaz!\n $(baz) |])" ==>
+             [ SpliceStart, T "foo", QuasiquoterStart, SpliceStart, T "baz"
+             , RParen, QuasiquoterEnd, RParen, Newline 0
+             ]
+        , "$(foo [bar| bar!\nbaz!\n $(baz) ⟧)" ==>
              [ SpliceStart, T "foo", QuasiquoterStart, SpliceStart, T "baz"
              , RParen, QuasiquoterEnd, RParen, Newline 0
              ]

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -146,6 +146,9 @@ testTokenize = testGroup "tokenize"
     , "showComplexFloat x 0.0 = showFFloat Nothing x \"\""
       ==>
       [T "showComplexFloat", T "x", Number, Equals, T "showFFloat", T "Nothing", T "x", String, Newline 0]
+    , "deriveJSON defaultOptions ''CI.CI"
+      ==>
+      [T "deriveJSON", T "defaultOptions", T "''CI.CI", Newline 0]
     , tokenizeSplices
     ]
     where
@@ -171,7 +174,15 @@ testTokenize = testGroup "tokenize"
             [ SpliceStart, T "foo", QuasiquoterStart, QuasiquoterEnd, RParen
             , Newline 0
             ]
-        , "$(foo [bar| baz ⟧)"                 ==>
+        , "$(foo [Foo.bar| baz ⟧)"                 ==>
+            [ SpliceStart, T "foo", QuasiquoterStart, QuasiquoterEnd, RParen
+            , Newline 0
+            ]
+        , "$(foo [$bar| baz |])"                 ==>
+            [ SpliceStart, T "foo", QuasiquoterStart, QuasiquoterEnd, RParen
+            , Newline 0
+            ]
+        , "$(foo [$Foo.bar| baz ⟧)"                 ==>
             [ SpliceStart, T "foo", QuasiquoterStart, QuasiquoterEnd, RParen
             , Newline 0
             ]
@@ -179,7 +190,15 @@ testTokenize = testGroup "tokenize"
              [ SpliceStart, T "foo", QuasiquoterStart, SpliceStart, T "baz"
              , RParen, QuasiquoterEnd, RParen, Newline 0
              ]
-        , "$(foo [bar| bar!\nbaz!\n $(baz) ⟧)" ==>
+        , "$(foo [Foo.bar| bar!\nbaz!\n $(baz) ⟧)" ==>
+             [ SpliceStart, T "foo", QuasiquoterStart, SpliceStart, T "baz"
+             , RParen, QuasiquoterEnd, RParen, Newline 0
+             ]
+        , "$(foo [$bar| bar!\nbaz!\n $(baz) |])" ==>
+             [ SpliceStart, T "foo", QuasiquoterStart, SpliceStart, T "baz"
+             , RParen, QuasiquoterEnd, RParen, Newline 0
+             ]
+        , "$(foo [$Foo.bar| bar!\nbaz!\n $(baz) ⟧)" ==>
              [ SpliceStart, T "foo", QuasiquoterStart, SpliceStart, T "baz"
              , RParen, QuasiquoterEnd, RParen, Newline 0
              ]
@@ -965,6 +984,7 @@ testFunctions = testGroup "functions"
         testGroup "toplevel functions without signatures"
         [ "$(return . map sumDeclaration $ [0..15])" ==> []
         , "$( fmap (reverse . concat) . traverse prismsForSingleType $ [1..15] )" ==> []
+        , "T.makeInstances [2..6]\nx" ==> []
         , "infix 5 |+|"  ==> []
         , "infixl 5 |+|" ==> []
         , "infixr 5 |+|" ==> []

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -562,6 +562,8 @@ testData = testGroup "data"
         ["Add", "X"]
     , "newtype (Eq a, Ord a) => X a = Add a"                            ==>
         ["Add", "X"]
+    , "newtype () => X a = Add a"                                     ==>
+        ["Add", "X"]
 
     , "newtype (u :*: v) z = X"                                         ==>
         [":*:", "X"]
@@ -575,6 +577,13 @@ testData = testGroup "data"
     , "data ((u :: (* -> *) -> *) :*: v) z = X"                         ==>
         [":*:", "X"]
     , "type ((u :: (* -> *) -> *) :*: v) z = (u, v, z)"                 ==>
+        [":*:"]
+
+    , "newtype () => ((u :: (* -> *) -> *) :*: v) z = X"        ==>
+        [":*:", "X"]
+    , "data () => ((u :: (* -> *) -> *) :*: v) z = X"           ==>
+        [":*:", "X"]
+    , "type () => ((u :: (* -> *) -> *) :*: v) z = (u, v, z)"   ==>
         [":*:"]
 
     , "newtype (Eq (v z)) => ((u :: (* -> *) -> *) :*: v) z = X"        ==>

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -767,6 +767,30 @@ testData = testGroup "data"
       \                                                , pos    :: v Int}     -- ^ the current position"
       ==>
       ["BindingList", "BindingList", "list", "pos", "source"]
+
+    , "data Tester a = Tester\n\
+      \    {(===) :: [String] -> a -> IO ()\n\
+      \    ,fails :: [String] -> IO ()\n\
+      \    ,isHelp :: [String] -> [String] -> IO ()\n\
+      \    ,isHelpNot :: [String] -> [String] -> IO ()\n\
+      \    ,isVersion :: [String] -> String -> IO ()\n\
+      \    ,isVerbosity :: [String] -> Verbosity -> IO ()\n\
+      \    ,completion :: [String] -> (Int,Int) -> [Complete] -> IO ()\n\
+      \    }"
+      ==>
+      ["===", "Tester", "Tester", "completion", "fails", "isHelp", "isHelpNot", "isVerbosity", "isVersion"]
+
+    , "data Tester a = Tester\n\
+      \    {(===) :: [String] -> a -> IO ()\n\
+      \    ,fails :: [String] -> IO ()\n\
+      \    ,isHelp, isHelpNot :: [String] -> [String] -> IO ()\n\
+      \    ,isVersion :: [String] -> String -> IO ()\n\
+      \    ,isVerbosity :: [String] -> Verbosity -> IO ()\n\
+      \    ,completion :: [String] -> (Int,Int) -> [Complete] -> IO ()\n\
+      \    }"
+      ==>
+      ["===", "Tester", "Tester", "completion", "fails", "isHelp", "isHelpNot", "isVerbosity", "isVersion"]
+
     ]
     where
     (==>) = testTagNames filename

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -117,6 +117,20 @@ testTokenize = testGroup "tokenize"
       \  \\x\" bar" ==>
         [ T "foo", Equals, String, T "bar", Newline 0]
 
+    , "{-   ___   -}import Data.Char;main=putStr$do{c<-\"/1 AA A A;9+ )11929 )1191A 2C9A \";e\n\
+      \ {- {- | -} -}  {- {- || -} -}{- {- || -} -}{- {- || -} -} {--}.(`divMod`8).(+(-32)).ord$c};f(0,0)=\"\n\";f(m,n)=m?\"  \"++n?\"_/\"\n\
+      \{- {- | -} -}n?x=do{[1..n];x}                                    --- obfuscated\n\
+      \{-\\_/ on Fairbairn, with apologies to Chris Brown. Above is / Haskell 98 -}"
+      ==>
+      [ KWImport, T "Data.Char", Semicolon
+      , T "main", Equals , T "putStr", T "$", KWDo, LBrace, T "c", T "<-", String, Semicolon, T "e", Newline 4
+      , Dot, LParen, Backtick, T "divMod", Backtick, T "8", RParen, Dot
+      , LParen, T "+", LParen, T "-", T "32", RParen, RParen, Dot, T "ord", T "$", T "c", RBrace, Semicolon
+      , T "f", LParen, T "0", Comma, T "0", RParen, Equals, String, Semicolon
+      , T "f", LParen, T "m", Comma, T "n", RParen, Equals, T "m", T "?", String, T "++", T "n", T "?", String, Newline 0
+      , T "n", T "?", T "x", Equals, KWDo, LBrace, LBracket, T "1", T "..", T "n", RBracket, Semicolon, T "x", RBrace, Newline 0, Newline 0
+      ]
+
     , "one_hash, two_hash :: text_type\n\
       \hash_prec :: Int -> Int\n\
       \one_hash  = from_char '#'\n\
@@ -188,7 +202,7 @@ testStripComments = testGroup "stripComments"
     , "hello -- {- there -}\nfred"                               ==>
         ["nl 0", "hello", "nl 0", "fred", "nl 0"]
     , "{-# LANG #-} hello {- there {- nested -} comment -} fred" ==>
-        ["nl 0", "hello", "fred", "nl 0"]
+        ["nl 1", "hello", "fred", "nl 0"]
     , "hello {-\nthere\n------}\n fred"                          ==>
         ["nl 0", "hello",  "nl 1", "fred", "nl 0"]
     , "hello {-  \nthere\n  ------}  \n fred"                    ==>
@@ -910,9 +924,15 @@ testFunctions = testGroup "functions"
       ==>
       ["."]
 
-    , "{- ___ -}import Data.Char;main=putStr$do{c<-\"/1 AA A A;9+ )11929 )1191A 2C9A \";e\n\
+    , "{- 123___ -}import Data.Char;main=putStr$do{c<-\"/1 AA A A;9+ )11929 )1191A 2C9A \";e\n\
       \{-  |  -}    .(`divMod`8).(+(-32)).ord$c};f(0,0)=\"\n\";f(m,n)=m?\"  \"++n?\"_/\"\n\
       \{-  |  -}n?x=do{[1..n];x}                                    --- obfuscated\n\
+      \{-\\_/ on Fairbairn, with apologies to Chris Brown. Above is / Haskell 98 -}"
+      ==>
+      ["?", "f", "main"]
+    , "{-   456___   -}import Data.Char;main=putStr$do{c<-\"/1 AA A A;9+ )11929 )1191A 2C9A \";e\n\
+      \ {- {- | -} -}  {- {- || -} -}{- {- || -} -}{- {- || -} -} {--}.(`divMod`8).(+(-32)).ord$c};f(0,0)=\"\n\";f(m,n)=m?\"  \"++n?\"_/\"\n\
+      \{- {- | -} -}n?x=do{[1..n];x}                                    --- obfuscated\n\
       \{-\\_/ on Fairbairn, with apologies to Chris Brown. Above is / Haskell 98 -}"
       ==>
       ["?", "f", "main"]

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -844,6 +844,16 @@ testGADT = testGroup "gadt"
       \  C :: { foo :: Int, bar :: Int -> Int } -> Rec a\n\
       \  D :: { baz :: (Int -> Int) -> Int, bar :: (((Int) -> (Int))) } -> Rec a"
       ==> ["C", "D", "Rec", "bar", "bar", "baz", "foo"]
+    , "newtype TyConProxy a b where\n\
+      \    TyConProxy :: () -> TyConProxy a b\n\
+      \  deriving ( Arbitrary\n\
+      \           , Show\n\
+      \           , Generic\n\
+      \#if defined(__LANGUAGE_DERIVE_GENERIC1__)\n\
+      \           , Generic1\n\
+      \#endif\n\
+      \           )"
+      ==> ["TyConProxy", "TyConProxy"]
     ]
     where
     (==>) = testTagNames filename

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -793,6 +793,18 @@ testData = testGroup "data"
       ==>
       ["===", "Tester", "Tester", "completion", "fails", "isHelp", "isHelpNot", "isVerbosity", "isVersion"]
 
+    , "-- | View of the right end of a sequence.\n\
+      \data ViewR s a\n\
+      \    = EmptyR\n\
+      \    | s a :> a"
+      ==>
+      [":>", "EmptyR", "ViewR"]
+    , "-- | View of the right end of a sequence.\n\
+      \data ViewR s a\n\
+      \    = s a :> a\n\
+      \    | EmptyR"
+      ==>
+      [":>", "EmptyR", "ViewR"]
     ]
     where
     (==>) = testTagNames filename

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -963,7 +963,9 @@ testFunctions = testGroup "functions"
     (==>) = testTagNames filename
     toplevelFunctionsWithoutSignatures =
         testGroup "toplevel functions without signatures"
-        [ "infix 5 |+|"  ==> []
+        [ "$(return . map sumDeclaration $ [0..15])" ==> []
+        , "$( fmap (reverse . concat) . traverse prismsForSingleType $ [1..15] )" ==> []
+        , "infix 5 |+|"  ==> []
         , "infixl 5 |+|" ==> []
         , "infixr 5 |+|" ==> []
         , "f = g"        ==> ["f"]


### PR DESCRIPTION
This PR contains many small things that I've been collecting for some time now. Some errors are no longer detected, a few new things (like type families or GADT-like newtypes (I was surprised, too)) are. Some functions I just tried to optimise. Not sure how to concisely summarise what was done - the best way to summarise is probaby to look at new test cases.

One significant improvement is to do with tracking of quasiquoters. Now lexer is smarter and tries to not confuse list comprehensions like `[foo|foo<-xs]` for quasiquoters by looking whether part of file after `[foo|` contains closing quasiquoter bracket `|]`. If it doesn't then we report a list comprehension and on some files start actually detecting the rest of the definitions.

One thing that does not fall under any of the improvements mentioned in the previous paragraphs but which I should nonetheless mention is addition of `parent` field to each tag. It does not appear in the output, so it should be safe w.r.t. backwards compatibility, but is very useful for using `fast-tags` package as a library to index some sources. I reckon it would not slow anything down since it's just a text field that gets populated when we now an entity (e.g. class, type declaration or type family) may have some related entities (children).