### PR TITLE
Reduce false positives from functions without signatures

### DIFF
--- a/src/FastTags/Tag.hs
+++ b/src/FastTags/Tag.hs
@@ -814,9 +814,9 @@ functionTags constructors = go []
 
     mkOpTag :: [Tag] -> Type -> Token -> [Tag]
     mkOpTag tags opTag' (Pos pos tok) =
-      case tokToOpName constructors tok of
-        Just name -> mkTag pos name opTag' : tags
-        Nothing   -> tags
+        case tokToOpName constructors tok of
+            Just name -> mkTag pos name opTag' : tags
+            Nothing   -> tags
 
 data ExpectedFuncName = ExpectFunctions | ExpectConstructors
 

--- a/src/FastTags/Tag.hs
+++ b/src/FastTags/Tag.hs
@@ -715,7 +715,12 @@ toplevelFunctionTags toks = case tags of
     toRepeatableTag t       = t
 
 functionTagsNoSig :: [Token] -> [Tag]
-functionTagsNoSig allToks = go' allToks
+functionTagsNoSig allToks
+    -- If there’s no equals sign then this is definitely not a function/operator declaration.
+    | any (\case { Pos _ Equals -> True; _ -> False; }) allToks
+    = go' allToks
+    | otherwise
+    = []
     where
     go' :: [Token] -> [Tag]
     go' (Pos _ T{} : Pos pos tok : _)
@@ -945,7 +950,6 @@ stripParensKindsTypeVars (Pos _ (T name) : xs)
 stripParensKindsTypeVars xs = xs
 
 stripOptContext :: [Token] -> [Token]
-stripOptContext (stripBalancedParens -> Pos _ Implies : xs) = xs
 stripOptContext (stripBalancedParens -> Pos _ Implies : xs) = xs
 stripOptContext origToks = go origToks
     where

--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -1583,6 +1583,27 @@ testFunctions = testGroup "functions"
       ==>
       ["FOO", "UnindentedImportList", "baz"]
 
+    , "\n\
+      \{-# LANGAUGE TemplateHaskell #-}\n\
+      \module Example where\n\
+      \\n\
+      \import Local.TH\n\
+      \concat <$> sequence [thFunc1, thFunc2]\n\
+      \\n\
+      \foo :: a -> a\n\
+      \foo x = x\n"
+      ==>
+      ["Example", "foo"]
+    , "\n\
+      \{-# LANGAUGE TemplateHaskell #-}\n\
+      \module Example where\n\
+      \\n\
+      \import Local.TH\n\
+      \concat <$> sequence [thFunc1, thFunc2]\n\
+      \\n"
+      ==>
+      ["Example"]
+
     , toplevelFunctionsWithoutSignatures
     ]
     where


### PR DESCRIPTION
Should fix #54. The fix's as suggested in the issue: if there's no `=` then don't produce anything.