### PR TITLE
Support Record Pattern Synonyms

### DIFF
--- a/tests/MainTest.hs
+++ b/tests/MainTest.hs
@@ -1974,6 +1974,22 @@ testPatterns = testGroup "patterns"
       \   (:>) x xs = Vec2 (x:unvec2 xs)"
       ==>
       [":>"]
+    , "\n\
+      \data Foo = Foo_ { _foo :: !(Last String) } deriving (Eq)\n\
+      \n\
+      \pattern Bar :: A -> B\n\
+      \pattern Bar { foo } = Foo_ (Last foo)\n\
+      \{-# COMPLETE Bar #-}\n"
+      ==>
+      ["Bar", "Foo", "Foo_", "_foo", "foo"]
+    , "\n\
+      \data Foo = Foo_ { _foo :: !(Last String), _bar :: !(Last String) } deriving (Eq)\n\
+      \n\
+      \pattern Bar :: A -> B\n\
+      \pattern Bar { foo, bar } = Foo_ (Last foo) (Last bar)\n\
+      \{-# COMPLETE Bar #-}\n"
+      ==>
+      ["Bar", "Foo", "Foo_", "_bar", "_foo", "bar", "foo"]
     ]
     where
     (==>) = testTagNames filename


### PR DESCRIPTION
This is probably one of the less known feauters but the `pattern Foo { bar } = ...` construct does sort of define the `bar` name in a sense. It's similar to a record label although not really since it cannot be used standalone (i.e. there's no accessor function being defined). Please consult GHC manual for more details https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/pattern_synonyms.html#record-pattern-synonyms.

Still I felt htat the name within braces should be searchable just like with vanilla records. Please voice your feedback if you think that that should not be the case.