### PR TITLE
Fix non-deterministic errors with GHC 9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         os: [ubuntu-latest]
         ghc: ['7.10', '8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0']
         include:
+        - os: macOS-latest
+          ghc: '9.0'
         - os: windows-latest
           ghc: '9.0'
     steps:

--- a/src/FastTags/Lexer.x
+++ b/src/FastTags/Lexer.x
@@ -357,7 +357,7 @@ scanTokens :: AlexM (Maybe Text)
 scanTokens = go
     where
     go = do
-        nextTok <- continueScanning
+        !nextTok <- continueScanning
         case nextTok of
             EOF       -> pure Nothing
             Error err -> pure $ Just err


### PR DESCRIPTION
Should fix https://github.com/elaforge/fast-tags/issues/53

The problem is that 9.0 seems to apply too aggressive optimizations which lead to some thunks, which depend on `withForeignPtr` being wrapped around them, outliving the foreign ptr bracket and thus reference garbage. Added `evaluate` call somewhat restricts the optimization. In 9.2 it works even without `evaluate`.